### PR TITLE
remove ubuntu-styles.css

### DIFF
--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -27,7 +27,6 @@
 
 <!-- google fonts -->
 <link href='https://fonts.googleapis.com/css?family=Ubuntu:400,300,300italic,400italic,700,700italic|Ubuntu+Mono' rel='stylesheet' type='text/css' />
-<link rel="stylesheet" type="text/css" media="screen" href="//assets.ubuntu.com/sites/guidelines/css/responsive/latest/ubuntu-styles.css" />
 <link rel="stylesheet" type="text/css" media="screen" href="//assets.ubuntu.com/sites/ubuntu/latest/u/css/beta/global-responsive.css" />
 <link rel="stylesheet" type="text/css" media="screen" href="{{ STATIC_URL }}css/styles.css" />
 <link rel="stylesheet" type="text/css" media="print" href="{{ STATIC_URL }}css/core-print.css" />


### PR DESCRIPTION
Done:
Removed the inclusion of ubuntu-styles.css

QA:
checkout the latest version of vanilla-framework into node_modules (going back to using bleeding edge until we get a newer version on NPM)

Check that the ubuntu-styles.css styling is removed.

NOTE: This will introduce many styling issues to the site; future PRs will fix the various problems
