### PR TITLE
fix to logo styling and markup

### DIFF
--- a/static/css/styles.scss
+++ b/static/css/styles.scss
@@ -234,12 +234,12 @@ blockquote.pull-quote p {
 header.banner {
 	border-bottom: none;
 
-	.nav-primary.nav-right .logo-ubuntu {
+	.nav-primary.nav-right .logo a {
 		@include background_size(130px 19px);
 		background-image: url(../img/logos/logo.svg);
 		background-position: 0 15px;
 		background-repeat: no-repeat;
-		min-width: 156px;
+		min-width: 127px;
 		padding-top: 10px;
 
 		img {
@@ -254,8 +254,8 @@ header.banner {
 	}
 }
 
-.opera-mini header.banner .logo-ubuntu,
-.no-svg header.banner .logo-ubuntu {
+.opera-mini header.banner .logo a,
+.no-svg header.banner .logo a {
 	background-image: url(../img/logos/logo.png);
 }
 

--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -49,7 +49,7 @@
 	<nav role="navigation" class="nav-primary nav-right" id="nav">
         <span id="main-navigation-link"><a href="#main-navigation">Jump to site nav</a></span>
 		<div class="logo">
-			<a class="logo-ubuntu" href="/">
+			<a href="/">
 				<img width="139" height="19" src="{{ STATIC_URL }}img/logos/footer_logo.png" alt="Canonical logo for print" />
 			</a>
 		</div>

--- a/templates/_base/header.html
+++ b/templates/_base/header.html
@@ -14,7 +14,7 @@
 		<li id="nav-partners"><a href="/partners">Partners</a></li>
 		<li><a href="http://shop.canonical.com/">Shop</a></li>
 	</ul>
-	<a class="logo-ubuntu" href="/">
-		<img width="118" height="27" src="{{ STATIC_URL }}img/logo.png" alt="Ubuntu logo"/>
+	<a href="/">
+		<img width="118" height="27" src="{{ STATIC_URL }}img/logo.png" alt="Canonical logo"/>
 	</a>
 </nav>


### PR DESCRIPTION
Done:
Made the naming sensible and updated the logo container sizing as per https://github.com/ubuntudesign/canonical-website/issues/10

QA:
Check that the logo displays and is now 127px wide.
