### PR TITLE
update 'we deliver ubuntu' row's height

### DIFF
--- a/static/css/section/_home.scss
+++ b/static/css/section/_home.scss
@@ -249,7 +249,7 @@ html.no-svg body.home {
 			.inner-wrapper {
 				overflow: visible;
 				position: relative;
-				min-height: 630px;
+				min-height: 450px;
 				padding-top: 135px;
 			}
 


### PR DESCRIPTION
Done:
Fixed the height of the .ubuntu-row row

QA:
Check the "We deliver ubuntu" row on the homepage and compare with live.
