### PR TITLE
add npm dependency on canonical-vanilla-framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "author": "Canonical webteam",
   "license": "LGPL v3",
   "dependencies": {
-    "vanilla-framework": "0.0.13"
+    "canonical-vanilla-theme": "0.0.13"
   }
 }


### PR DESCRIPTION
Done:
Added the canonical-vanilla-theme dependency

QA:
npm install
make it so

Check in-browser that the site is basically fine (but most-importantly that the CSS built without error).
