### PR TITLE
updated news and resources block to use new, non-google feed api, javascript

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -7,28 +7,28 @@
 {% block extra_body_class %}about-home{% endblock %}
 
 {% block head_extra %}
-	<script src="http://www.google.com/jsapi"></script>
-	<script>google.load("feeds", "1")</script>
+  <script src="//assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
+  <script src="//assets.ubuntu.com/v1/c954db4a-jfeed_prm.js"></script>
 {% endblock %}
 
 {% block content %}
 <div class="row row-hero">
-	<div class="inner-wrapper">
-		<div class="eight-col">
-			<h1>At Canonical, we believe in the power of open source to change the world</h1>
-		</div>
-		<div class="four-col last-col text-center">
-			<img src="{{ ASSET_SERVER_URL }}63127ce2-hero-about-small.png" alt="" />
-		</div><!-- /col -->
-		<div class="six-col">
-			<p class="intro">Canonical was created alongside Ubuntu to help it reach a wider market. Our services help governments and businesses the world over with migrations, management and support for their Ubuntu deployments. Together with our partners, we ensure that Ubuntu runs reliably on every platform from the PC and the smartphone to the server and, crucially, the&nbsp;cloud.</p>
-		</div><!-- /col -->
-	</div><!-- /inner-wrapper -->
+  <div class="inner-wrapper">
+    <div class="eight-col">
+      <h1>At Canonical, we believe in the power of open source to change the world</h1>
+    </div>
+    <div class="four-col last-col text-center">
+      <img src="{{ ASSET_SERVER_URL }}63127ce2-hero-about-small.png" alt="" />
+    </div><!-- /col -->
+    <div class="six-col">
+      <p class="intro">Canonical was created alongside Ubuntu to help it reach a wider market. Our services help governments and businesses the world over with migrations, management and support for their Ubuntu deployments. Together with our partners, we ensure that Ubuntu runs reliably on every platform from the PC and the smartphone to the server and, crucially, the&nbsp;cloud.</p>
+    </div><!-- /col -->
+  </div><!-- /inner-wrapper -->
 </div><!-- /row -->
 
 <div class="strip-dark row med-six-col">
-	<div class="inner-wrapper">
-		<h2>What we do</h2>
+  <div class="inner-wrapper">
+    <h2>What we do</h2>
         <ul class="connected-list">
             <li class="three-col">
                 <img src="{{ ASSET_SERVER_URL }}0948d424-icon-ubuntu.svg" class="icon" alt="" />
@@ -48,7 +48,7 @@
             </li>
             <li class="three-col bottom-row">
                 <img src="{{ ASSET_SERVER_URL }}41348d1c-icon-dictionary.svg" class="icon" alt="" />
-				<p>We promote the use of open source in education, leading to large-scale desktop migrations covering hundreds of thousands of machines.</p>
+        <p>We promote the use of open source in education, leading to large-scale desktop migrations covering hundreds of thousands of machines.</p>
             </li>
             <li class="three-col bottom-row">
                 <img src="{{ ASSET_SERVER_URL }}d3488ab5-icon-time.svg" class="icon" alt="" />
@@ -63,350 +63,350 @@
 </div><!-- /row -->
 
 <div class="row strip-light">
-	<div class="inner-wrapper">
-		<div class="seven-col">
-			<h2>Canonical and open source</h2>
-			<p>We believe in the power of open source software; Ubuntu could not exist without its worldwide community of voluntary developers. We are committed to creating it, refining it, certifying it for reliability and promoting its use. As well as launching and running our own projects, we contribute staff, code and funding to many more.</p>
-			<p><a href="/projects">Open source projects &rsaquo;</a></p>
-		</div>
-		<div class="text-center five-col last-col">
-			<img src="{{ ASSET_SERVER_URL }}45888d3f-image-picto-projects-we-love.svg" width="195" height="196" alt="Heart pictogram" class="priority-0" />
-		</div><!-- /col -->
-	</div><!-- /inner-wrapper -->
+  <div class="inner-wrapper">
+    <div class="seven-col">
+      <h2>Canonical and open source</h2>
+      <p>We believe in the power of open source software; Ubuntu could not exist without its worldwide community of voluntary developers. We are committed to creating it, refining it, certifying it for reliability and promoting its use. As well as launching and running our own projects, we contribute staff, code and funding to many more.</p>
+      <p><a href="/projects">Open source projects &rsaquo;</a></p>
+    </div>
+    <div class="text-center five-col last-col">
+      <img src="{{ ASSET_SERVER_URL }}45888d3f-image-picto-projects-we-love.svg" width="195" height="196" alt="Heart pictogram" class="priority-0" />
+    </div><!-- /col -->
+  </div><!-- /inner-wrapper -->
 </div><!-- /row -->
 
 <div class="row join">
-	<div class="inner-wrapper">
-		<div class="twelve-col no-margin-bottom">
-			<h2>Our management team</h2>
-		</div>
-		<div class="three-col no-margin-bottom">
-			<div class="tabbed-menu">
-				<ul class="no-bullets">
-					<li><a class="active slideless" href="#jane-silber">Jane Silber</a></li>
-					<li><a class="slideless" href="#mark-shuttleworth">Mark Shuttleworth</a></li>
-					<li><a class="slideless" href="#anand-krishnan">Anand Krishnan</a></li>
-					<li><a class="slideless" href="#rick-spencer">Rick Spencer</a></li>
-					<li><a class="slideless" href="#robbie-williamson">Robbie Williamson</a></li>
-					<li><a class="slideless" href="#chris-kenyon">Chris Kenyon</a></li>
-					<li><a class="slideless" href="#neil-french">Neil French</a></li>
-				</ul>
-			</div><!-- /tabbed-menu -->
-			<img src="http://www.ubuntu.com/static/u/img/patterns/tabbed-nav-arrow.png" class="arrow" height="6" width="12" alt="" />
-		</div><!-- /col -->
-		<div id="jane-silber" class="tabbed-content panel nine-col last-col" itemscope itemtype="http://schema.org/Person">
-			<a class="accordion-button slideless" href="#jane-silber">Jane Silber</a>
-			<div class="nine-col">
-				<div class="five-col">
-					<div class="clearfix">
-						<img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}9b7bf471-jane-silber.png" alt="" />
-						<h3 itemprop="name">Jane Silber</h3>
-						<p itemprop="jobTitle" class="role">Chief Executive Officer</p>
-					</div>
-					<p itemprop="description">Jane has over 20 years&rsquo; experience in business development, operations and software management. Before becoming Canonical&rsquo;s CEO in 2010, Jane held VP roles at Canonical, Interactive Television Company and General Dynamics C4 Systems. </p>
-					<p><a href="https://twitter.com/silbs" class="external">Follow Jane on Twitter</a></p>
-				</div><!-- /col -->
-				<div class="four-col last-col">
-					<blockquote class="pull-quote">
-						<p><span>&ldquo;</span>As Ubuntu becomes the open-source standard in so many markets, our portfolio continues to flourish. I can&rsquo;t imagine a better place to work.<span>&rdquo;</span></p>
-					</blockquote>
-				</div><!-- /col -->
-			</div><!-- /col -->
-		</div><!-- /person -->
-		<div id="mark-shuttleworth" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-			<a class="accordion-button slideless" href="#mark-shuttleworth">Mark Shuttleworth</a>
-			<div class="nine-col">
-				<div class="five-col">
-					<div class="clearfix">
-						<img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}27d4e2ca-mark-shuttleworth.png" alt="" />
-						<h3 itemprop="name">Mark Shuttleworth</h3>
-						<p itemprop="jobTitle" class="role">Founder</p>
-					</div>
-					<p itemprop="description">Mark founded security specialist Thawte before selling the company to VeriSign in 1999. In 2004, he founded Ubuntu and Canonical, combining responsibility for strategy and user experience at Canonical with roles on the Ubuntu Technical Board and Community Council.</p>
-					<p><a href="http://markshuttleworth.com" class="external">Read Mark&rsquo;s blog</a></p>
-					<p><a href="https://plus.google.com/103552930976410494054/posts" class="external">Follow Mark on Google+</a></p>
-				</div>
-				<div class="four-col last-col">
-					<blockquote class="pull-quote">
-						<p><span>&ldquo;</span>Contributing to Ubuntu is a profession for some and a passion for others. Either way, it&rsquo;s changing the world.<span>&rdquo;</span></p>
-					</blockquote>
-				</div>
-			</div>
-		</div>
-		<div id="anand-krishnan" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-			<a class="accordion-button slideless" href="#anand-krishnan">Anand Krishnan</a>
-			<div class="nine-col">
-				<div class="five-col">
-					<div class="clearfix">
-						<img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}5bb34ed1-anand-krishnan.png" alt="" />
-						<h3 itemprop="name">Anand Krishnan</h3>
-						<p itemprop="jobTitle" class="role">EVP, Cloud</p>
-					</div>
-					<p itemprop="description">Anand heads up Canonical&rsquo;s cloud division and is responsible for all cloud product, marketing, sales, business-development and support. Anand measures his days by the number of happy customers using our cloud stack and tooling. Before joining Canonical, Anand held several leadership positions at Microsoft Corp and helped launch and build several successful businesses both at Microsoft and in the startup world prior to that.</p>
-					<p><a href="https://www.linkedin.com/in/akris" class="external">View Anand on LinkedIn</a></p>
-				</div><!-- /col -->
-				<div class="four-col last-col">
-					<blockquote class="pull-quote">
-						<p><span>&ldquo;</span>Helping customers build and use the cloud that best fits them &mdash; our mission is to make that a reality for any customer of any size.<span>&rdquo;</span></p>
-					</blockquote>
-				</div><!-- /col -->
-			</div><!-- /col -->
-		</div><!-- /person -->
-		<div id="rick-spencer" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-			<a class="accordion-button slideless" href="#rick-spencer">Rick Spencer</a>
-			<div class="nine-col">
-				<div class="five-col">
-					<div class="clearfix">
-						<img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}f3b22374-rick-spencer.png" alt="" />
-						<h3 itemprop="name">Rick Spencer</h3>
-						<p itemprop="jobTitle" class="role">VP, Ubuntu Engineering</p>
-					</div>
-					<p itemprop="description">Rick leads the team responsible for Canonical&rsquo;s numerous engineering contributions to Ubuntu. Before joining the company, he spent many years in software development, including almost a decade in developer experience and management roles at Microsoft. </p>
-					<p><a href="http://theravingrick.blogspot.co.uk/" class="external">Read Rick&rsquo;s blog</a></p>
-					<p><a href="https://twitter.com/rickspencer3" class="external">Follow Rick on Twitter</a></p>
-				</div>
-				<div class="four-col last-col">
-					<blockquote class="pull-quote">
-						<p><span>&ldquo;</span>Through a unique combination of stellar people, engaged community, strong principles, and ever improving technology, I believe Ubuntu will make the world a better place.<span>&rdquo;</span></p>
-					</blockquote>
-				</div>
-			</div>
-		</div>
-		<div id="robbie-williamson" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-			<a class="accordion-button slideless" href="#robbie-williamson">Robbie Williamson</a>
-			<div class="nine-col">
-				<div class="five-col">
-					<div class="clearfix">
-						<img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}6dad5352-robbie-williamson.png" alt="" />
-						<h3 itemprop="name">Robbie Williamson</h3>
-						<p itemprop="jobTitle" class="role large-role">VP, Cloud Development and Operations</p>
-					</div>
-					<p itemprop="description">Robbie leads our Cloud and DevOps engineering efforts, plus a world-class operations team delivering services  to the company, our customers and the Ubuntu community. Before  Canonical, Robbie held several managerial positions within IBM's Linux Technology Center.</p>
-					<p><a href="http://undacuvabrutha.wordpress.com/" class="external">Read Robbie&rsquo;s blog</a></p>
-					<p><a href="https://twitter.com/ubuhulk" class="external">Follow Robbie on Twitter</a></p>
-				</div>
-				<div class="four-col last-col">
-					<blockquote class="pull-quote">
-						<p><span>&ldquo;</span>Everything we do reflects our ability to be progressive in thought, innovative in design, adroit in delivery, and disruptive in the markets we target.<span>&rdquo;</span></p>
-					</blockquote>
-				</div>
-			</div>
-		</div>
-		<div id="chris-kenyon" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-			<a class="accordion-button slideless" href="#chris-kenyon">Chris Kenyon</a>
-			<div class="nine-col">
-				<div class="five-col">
-					<div class="clearfix">
-						<img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}e4953a3b-chris-kenyon.png" alt="" />
-						<h3 itemprop="name">Chris Kenyon</h3>
-						<p itemprop="jobTitle" class="role large-role">SVP, Cloud Sales and Business Development</p>
-					</div>
-					<p itemprop="description">Chris is responsible for the commercial success of Ubuntu in both public and private cloud. He is responsible for Canonical&rsquo;s direct and channel business around Ubuntu Openstack as well as Canonical&rsquo;s global partnerships with the likes of IBM, HP, Cisco, Dell, Amazon Web Services, Microsoft Azure.</p>
-					<p><a href="https://twitter.com/ChrisKenyonEU" class="external">Follow Chris on Twitter</a></p>
-				</div>
-				<div class="four-col last-col">
-					<blockquote class="pull-quote">
-						<p><span>&ldquo;</span>Ubuntu is born of the cloud &mdash; Both the industry standard for Ubuntu Openstack and the world&rsquo;s leading cloud guest. We help companies get the most from&nbsp;it.<span>&rdquo;</span></p>
-					</blockquote>
-				</div>
-			</div>
-		</div>
-		<div id="neil-french" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-			<a class="accordion-button slideless" href="#neil-french">Neil French</a>
-			<div class="nine-col">
-				<div class="five-col">
-					<div class="clearfix">
-						<img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}b1a77511-neil-french.png" alt="" />
-						<h3 itemprop="name">Neil French</h3>
-						<p itemprop="jobTitle" class="role">VP, Operations</p>
-					</div><!-- /clearfix -->
-					<p itemprop="description">Neil is responsible for all of Canonical&rsquo;s internal operations.  Before joining Canonical, he was the Director of Commercial Operations at Thomsons Online Benefits, the leading Software-as-a-Service provider for global employee benefits administration, and before that held business and product leadership roles at Epson, 3Com and Hewlett-Packard.</p>
-					<p><a href="http://twitter.com/nrfrench" class="external">Follow Neil on twitter</a></p>
-				</div><!-- /col -->
-				<div class="four-col last-col">
-					<blockquote class="pull-quote">
-						<p><span>&ldquo;</span>Canonical is perfectly positioned to drive key changes happening in the technology industry today. I&rsquo;m excited to be supporting this talented team to achieve those goals and deliver excellent products and services to our customers and partners<span>&rdquo;</span></p>
-					</blockquote>
-				</div><!-- /col -->
-			</div><!-- /col -->
-		</div><!-- /person -->
-	</div>
+  <div class="inner-wrapper">
+    <div class="twelve-col no-margin-bottom">
+      <h2>Our management team</h2>
+    </div>
+    <div class="three-col no-margin-bottom">
+      <div class="tabbed-menu">
+        <ul class="no-bullets">
+          <li><a class="active slideless" href="#jane-silber">Jane Silber</a></li>
+          <li><a class="slideless" href="#mark-shuttleworth">Mark Shuttleworth</a></li>
+          <li><a class="slideless" href="#anand-krishnan">Anand Krishnan</a></li>
+          <li><a class="slideless" href="#rick-spencer">Rick Spencer</a></li>
+          <li><a class="slideless" href="#robbie-williamson">Robbie Williamson</a></li>
+          <li><a class="slideless" href="#chris-kenyon">Chris Kenyon</a></li>
+          <li><a class="slideless" href="#neil-french">Neil French</a></li>
+        </ul>
+      </div><!-- /tabbed-menu -->
+      <img src="http://www.ubuntu.com/static/u/img/patterns/tabbed-nav-arrow.png" class="arrow" height="6" width="12" alt="" />
+    </div><!-- /col -->
+    <div id="jane-silber" class="tabbed-content panel nine-col last-col" itemscope itemtype="http://schema.org/Person">
+      <a class="accordion-button slideless" href="#jane-silber">Jane Silber</a>
+      <div class="nine-col">
+        <div class="five-col">
+          <div class="clearfix">
+            <img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}9b7bf471-jane-silber.png" alt="" />
+            <h3 itemprop="name">Jane Silber</h3>
+            <p itemprop="jobTitle" class="role">Chief Executive Officer</p>
+          </div>
+          <p itemprop="description">Jane has over 20 years&rsquo; experience in business development, operations and software management. Before becoming Canonical&rsquo;s CEO in 2010, Jane held VP roles at Canonical, Interactive Television Company and General Dynamics C4 Systems. </p>
+          <p><a href="https://twitter.com/silbs" class="external">Follow Jane on Twitter</a></p>
+        </div><!-- /col -->
+        <div class="four-col last-col">
+          <blockquote class="pull-quote">
+            <p><span>&ldquo;</span>As Ubuntu becomes the open-source standard in so many markets, our portfolio continues to flourish. I can&rsquo;t imagine a better place to work.<span>&rdquo;</span></p>
+          </blockquote>
+        </div><!-- /col -->
+      </div><!-- /col -->
+    </div><!-- /person -->
+    <div id="mark-shuttleworth" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
+      <a class="accordion-button slideless" href="#mark-shuttleworth">Mark Shuttleworth</a>
+      <div class="nine-col">
+        <div class="five-col">
+          <div class="clearfix">
+            <img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}27d4e2ca-mark-shuttleworth.png" alt="" />
+            <h3 itemprop="name">Mark Shuttleworth</h3>
+            <p itemprop="jobTitle" class="role">Founder</p>
+          </div>
+          <p itemprop="description">Mark founded security specialist Thawte before selling the company to VeriSign in 1999. In 2004, he founded Ubuntu and Canonical, combining responsibility for strategy and user experience at Canonical with roles on the Ubuntu Technical Board and Community Council.</p>
+          <p><a href="http://markshuttleworth.com" class="external">Read Mark&rsquo;s blog</a></p>
+          <p><a href="https://plus.google.com/103552930976410494054/posts" class="external">Follow Mark on Google+</a></p>
+        </div>
+        <div class="four-col last-col">
+          <blockquote class="pull-quote">
+            <p><span>&ldquo;</span>Contributing to Ubuntu is a profession for some and a passion for others. Either way, it&rsquo;s changing the world.<span>&rdquo;</span></p>
+          </blockquote>
+        </div>
+      </div>
+    </div>
+    <div id="anand-krishnan" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
+      <a class="accordion-button slideless" href="#anand-krishnan">Anand Krishnan</a>
+      <div class="nine-col">
+        <div class="five-col">
+          <div class="clearfix">
+            <img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}5bb34ed1-anand-krishnan.png" alt="" />
+            <h3 itemprop="name">Anand Krishnan</h3>
+            <p itemprop="jobTitle" class="role">EVP, Cloud</p>
+          </div>
+          <p itemprop="description">Anand heads up Canonical&rsquo;s cloud division and is responsible for all cloud product, marketing, sales, business-development and support. Anand measures his days by the number of happy customers using our cloud stack and tooling. Before joining Canonical, Anand held several leadership positions at Microsoft Corp and helped launch and build several successful businesses both at Microsoft and in the startup world prior to that.</p>
+          <p><a href="https://www.linkedin.com/in/akris" class="external">View Anand on LinkedIn</a></p>
+        </div><!-- /col -->
+        <div class="four-col last-col">
+          <blockquote class="pull-quote">
+            <p><span>&ldquo;</span>Helping customers build and use the cloud that best fits them &mdash; our mission is to make that a reality for any customer of any size.<span>&rdquo;</span></p>
+          </blockquote>
+        </div><!-- /col -->
+      </div><!-- /col -->
+    </div><!-- /person -->
+    <div id="rick-spencer" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
+      <a class="accordion-button slideless" href="#rick-spencer">Rick Spencer</a>
+      <div class="nine-col">
+        <div class="five-col">
+          <div class="clearfix">
+            <img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}f3b22374-rick-spencer.png" alt="" />
+            <h3 itemprop="name">Rick Spencer</h3>
+            <p itemprop="jobTitle" class="role">VP, Ubuntu Engineering</p>
+          </div>
+          <p itemprop="description">Rick leads the team responsible for Canonical&rsquo;s numerous engineering contributions to Ubuntu. Before joining the company, he spent many years in software development, including almost a decade in developer experience and management roles at Microsoft. </p>
+          <p><a href="http://theravingrick.blogspot.co.uk/" class="external">Read Rick&rsquo;s blog</a></p>
+          <p><a href="https://twitter.com/rickspencer3" class="external">Follow Rick on Twitter</a></p>
+        </div>
+        <div class="four-col last-col">
+          <blockquote class="pull-quote">
+            <p><span>&ldquo;</span>Through a unique combination of stellar people, engaged community, strong principles, and ever improving technology, I believe Ubuntu will make the world a better place.<span>&rdquo;</span></p>
+          </blockquote>
+        </div>
+      </div>
+    </div>
+    <div id="robbie-williamson" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
+      <a class="accordion-button slideless" href="#robbie-williamson">Robbie Williamson</a>
+      <div class="nine-col">
+        <div class="five-col">
+          <div class="clearfix">
+            <img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}6dad5352-robbie-williamson.png" alt="" />
+            <h3 itemprop="name">Robbie Williamson</h3>
+            <p itemprop="jobTitle" class="role large-role">VP, Cloud Development and Operations</p>
+          </div>
+          <p itemprop="description">Robbie leads our Cloud and DevOps engineering efforts, plus a world-class operations team delivering services  to the company, our customers and the Ubuntu community. Before  Canonical, Robbie held several managerial positions within IBM's Linux Technology Center.</p>
+          <p><a href="http://undacuvabrutha.wordpress.com/" class="external">Read Robbie&rsquo;s blog</a></p>
+          <p><a href="https://twitter.com/ubuhulk" class="external">Follow Robbie on Twitter</a></p>
+        </div>
+        <div class="four-col last-col">
+          <blockquote class="pull-quote">
+            <p><span>&ldquo;</span>Everything we do reflects our ability to be progressive in thought, innovative in design, adroit in delivery, and disruptive in the markets we target.<span>&rdquo;</span></p>
+          </blockquote>
+        </div>
+      </div>
+    </div>
+    <div id="chris-kenyon" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
+      <a class="accordion-button slideless" href="#chris-kenyon">Chris Kenyon</a>
+      <div class="nine-col">
+        <div class="five-col">
+          <div class="clearfix">
+            <img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}e4953a3b-chris-kenyon.png" alt="" />
+            <h3 itemprop="name">Chris Kenyon</h3>
+            <p itemprop="jobTitle" class="role large-role">SVP, Cloud Sales and Business Development</p>
+          </div>
+          <p itemprop="description">Chris is responsible for the commercial success of Ubuntu in both public and private cloud. He is responsible for Canonical&rsquo;s direct and channel business around Ubuntu Openstack as well as Canonical&rsquo;s global partnerships with the likes of IBM, HP, Cisco, Dell, Amazon Web Services, Microsoft Azure.</p>
+          <p><a href="https://twitter.com/ChrisKenyonEU" class="external">Follow Chris on Twitter</a></p>
+        </div>
+        <div class="four-col last-col">
+          <blockquote class="pull-quote">
+            <p><span>&ldquo;</span>Ubuntu is born of the cloud &mdash; Both the industry standard for Ubuntu Openstack and the world&rsquo;s leading cloud guest. We help companies get the most from&nbsp;it.<span>&rdquo;</span></p>
+          </blockquote>
+        </div>
+      </div>
+    </div>
+    <div id="neil-french" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
+      <a class="accordion-button slideless" href="#neil-french">Neil French</a>
+      <div class="nine-col">
+        <div class="five-col">
+          <div class="clearfix">
+            <img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}b1a77511-neil-french.png" alt="" />
+            <h3 itemprop="name">Neil French</h3>
+            <p itemprop="jobTitle" class="role">VP, Operations</p>
+          </div><!-- /clearfix -->
+          <p itemprop="description">Neil is responsible for all of Canonical&rsquo;s internal operations.  Before joining Canonical, he was the Director of Commercial Operations at Thomsons Online Benefits, the leading Software-as-a-Service provider for global employee benefits administration, and before that held business and product leadership roles at Epson, 3Com and Hewlett-Packard.</p>
+          <p><a href="http://twitter.com/nrfrench" class="external">Follow Neil on twitter</a></p>
+        </div><!-- /col -->
+        <div class="four-col last-col">
+          <blockquote class="pull-quote">
+            <p><span>&ldquo;</span>Canonical is perfectly positioned to drive key changes happening in the technology industry today. I&rsquo;m excited to be supporting this talented team to achieve those goals and deliver excellent products and services to our customers and partners<span>&rdquo;</span></p>
+          </blockquote>
+        </div><!-- /col -->
+      </div><!-- /col -->
+    </div><!-- /person -->
+  </div>
 </div><!-- /inner-wrapper -->
 </div><!-- /row -->
 
 <div id="office-row" class="the-map">
-	<div id="map-canvas"></div>
-	<div class="map-shadow-top"></div>
-	<div class="map-shadow-bottom"></div>
+  <div id="map-canvas"></div>
+  <div class="map-shadow-top"></div>
+  <div class="map-shadow-bottom"></div>
 </div>
 <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&amp;sensor=false"></script>
 <script>
 function initialize() {
-	var starting = new google.maps.LatLng(40,0);
-	var mapOptions = {
-		zoom: 3,
-		scrollwheel: false,
-		center: starting
-	}
-	var map = new google.maps.Map(document.getElementById('map-canvas'), mapOptions);
+  var starting = new google.maps.LatLng(40,0);
+  var mapOptions = {
+    zoom: 3,
+    scrollwheel: false,
+    center: starting
+  }
+  var map = new google.maps.Map(document.getElementById('map-canvas'), mapOptions);
 
-	var londonInfo = new google.maps.InfoWindow({
-	    content: '<h2>London, United Kingdom</h2>' +
-	    		'<p>Canonical Group Limited <br />' +
-	    		'5th Floor, Blue Fin Building <br />' +
-	    		'110 Southwark Street <br />' +
-	    		'London SE1 0SU<br />United Kingdom</p>'
-	});
-	var bostonInfo = new google.maps.InfoWindow({
-	    content: '<h2>Boston, United States</h2>' +
-				'<p>Canonical USA Inc. <br />' +
-				'Suite 212 Lexington Corporate Center <br />' +
-				'10 Maguire Road <br />' +
-				'Lexington, MA 02421 <br />' +
-				'United States of America</p>'
-	});
-	var shanghaiInfo = new google.maps.InfoWindow({
-	    content: '<h2>Shanghai, China</h2>' +
-				'<p>Room 1246, 12F <br />' +
-				'No. 331 North Caoxi Road <br />' +
-				'Shanghai 200031 <br />' +
-				'China <br />' +
-				'上海市漕溪北路331号12楼1246室 200231</p>'
-	});
-	var beijingInfo = new google.maps.InfoWindow({
-	    content: '<h2>Beijing, China</h2>' +
-				'<p>Room 17- 01Z, Floor B17, 101 Nei, Floor 3- 24<br />' +
-				'No. 3, Xinyuan South Road, Chaoyang District <br />' +
-				'Beijing P.R.C. 100027 <br />' +
-				'China <br />' +
-				'北京市朝阳区新源南路3号- 3至24层101内B17层17- 01Z室 100027</p>'
-	});
-	var taipeiInfo = new google.maps.InfoWindow({
-	    content: '<h2>Taipei, Taiwan</h2>' +
-				'<p>Canonical Limited Taiwan Branch <br />' +
-				'Room D, 46F,  <br />' +
-				'No. 7, Xin Yi Rd., Sec.5, <br />' +
-				'Taipei 101  <br />' +
-				'Taiwan</p>'
-	});
-	var iomInfo = new google.maps.InfoWindow({
-	    content: '<h2>Isle of Man</h2>' +
-				'<p>Canonical Limited  <br />' +
-				'One Circular Road  <br />' +
-				'Douglas  <br />' +
-				'Isle of Man  <br />' +
-				'IM1 1SB</p>'
-	});
-	var japanInfo = new google.maps.InfoWindow({
-	    content: '<h2>Tokyo, Japan</h2>' +
-				'<p>Canonical Limited  <br />' +
-				'Level 21, Shiodome Shibarikyu Building  <br />' +
-				'1-2-3 Kalgan  <br />' +
-				'Minato-ku  <br />' +
-				'Tokyo 105-0022 <br />' +
-				'Japan </p>'
-	});
+  var londonInfo = new google.maps.InfoWindow({
+      content: '<h2>London, United Kingdom</h2>' +
+          '<p>Canonical Group Limited <br />' +
+          '5th Floor, Blue Fin Building <br />' +
+          '110 Southwark Street <br />' +
+          'London SE1 0SU<br />United Kingdom</p>'
+  });
+  var bostonInfo = new google.maps.InfoWindow({
+      content: '<h2>Boston, United States</h2>' +
+        '<p>Canonical USA Inc. <br />' +
+        'Suite 212 Lexington Corporate Center <br />' +
+        '10 Maguire Road <br />' +
+        'Lexington, MA 02421 <br />' +
+        'United States of America</p>'
+  });
+  var shanghaiInfo = new google.maps.InfoWindow({
+      content: '<h2>Shanghai, China</h2>' +
+        '<p>Room 1246, 12F <br />' +
+        'No. 331 North Caoxi Road <br />' +
+        'Shanghai 200031 <br />' +
+        'China <br />' +
+        '上海市漕溪北路331号12楼1246室 200231</p>'
+  });
+  var beijingInfo = new google.maps.InfoWindow({
+      content: '<h2>Beijing, China</h2>' +
+        '<p>Room 17- 01Z, Floor B17, 101 Nei, Floor 3- 24<br />' +
+        'No. 3, Xinyuan South Road, Chaoyang District <br />' +
+        'Beijing P.R.C. 100027 <br />' +
+        'China <br />' +
+        '北京市朝阳区新源南路3号- 3至24层101内B17层17- 01Z室 100027</p>'
+  });
+  var taipeiInfo = new google.maps.InfoWindow({
+      content: '<h2>Taipei, Taiwan</h2>' +
+        '<p>Canonical Limited Taiwan Branch <br />' +
+        'Room D, 46F,  <br />' +
+        'No. 7, Xin Yi Rd., Sec.5, <br />' +
+        'Taipei 101  <br />' +
+        'Taiwan</p>'
+  });
+  var iomInfo = new google.maps.InfoWindow({
+      content: '<h2>Isle of Man</h2>' +
+        '<p>Canonical Limited  <br />' +
+        'One Circular Road  <br />' +
+        'Douglas  <br />' +
+        'Isle of Man  <br />' +
+        'IM1 1SB</p>'
+  });
+  var japanInfo = new google.maps.InfoWindow({
+      content: '<h2>Tokyo, Japan</h2>' +
+        '<p>Canonical Limited  <br />' +
+        'Level 21, Shiodome Shibarikyu Building  <br />' +
+        '1-2-3 Kalgan  <br />' +
+        'Minato-ku  <br />' +
+        'Tokyo 105-0022 <br />' +
+        'Japan </p>'
+  });
 
 
-	var london = new google.maps.Marker({
-	    position: new google.maps.LatLng(51.506312,-0.099871),
-	    map: map,
-	    title:"London, United Kingdom"
-	});
-	var boston = new google.maps.Marker({
-	    position: new google.maps.LatLng(42.428691,-71.228023),
-	    map: map,
-	    title:"Boston, United States"
-	});
-	var shanghai = new google.maps.Marker({
-	    position: new google.maps.LatLng(31.1747322,121.4351965),
-	    map: map,
-	    title:"Shanghai, China"
-	});
-	var beijing = new google.maps.Marker({
-	    position: new google.maps.LatLng(39.940926,116.447657),
-	    map: map,
-	    title:"Beijing, China"
-	});
-	var taipei = new google.maps.Marker({
-	    position: new google.maps.LatLng(25.091075,121.559834),
-	    map: map,
-	    title:"Taipei, Taiwan"
-	});
-	var iom = new google.maps.Marker({
-	    position: new google.maps.LatLng(54.15272,-4.487221),
-	    map: map,
-	    title:"Isle of Man"
-	});
-	var japan = new google.maps.Marker({
-	    position: new google.maps.LatLng(35.6472046,139.758064),
-	    map: map,
-	    title:"Japan"
-	});
+  var london = new google.maps.Marker({
+      position: new google.maps.LatLng(51.506312,-0.099871),
+      map: map,
+      title:"London, United Kingdom"
+  });
+  var boston = new google.maps.Marker({
+      position: new google.maps.LatLng(42.428691,-71.228023),
+      map: map,
+      title:"Boston, United States"
+  });
+  var shanghai = new google.maps.Marker({
+      position: new google.maps.LatLng(31.1747322,121.4351965),
+      map: map,
+      title:"Shanghai, China"
+  });
+  var beijing = new google.maps.Marker({
+      position: new google.maps.LatLng(39.940926,116.447657),
+      map: map,
+      title:"Beijing, China"
+  });
+  var taipei = new google.maps.Marker({
+      position: new google.maps.LatLng(25.091075,121.559834),
+      map: map,
+      title:"Taipei, Taiwan"
+  });
+  var iom = new google.maps.Marker({
+      position: new google.maps.LatLng(54.15272,-4.487221),
+      map: map,
+      title:"Isle of Man"
+  });
+  var japan = new google.maps.Marker({
+      position: new google.maps.LatLng(35.6472046,139.758064),
+      map: map,
+      title:"Japan"
+  });
 
-	google.maps.event.addListener(london, 'click', function() {
-		bostonInfo.close();
-		shanghaiInfo.close();
-		beijingInfo.close();
-		taipeiInfo.close();
-		iomInfo.close();
-		japanInfo.close();
-	    londonInfo.open(map,london);
-	});
-	google.maps.event.addListener(boston, 'click', function() {
-		londonInfo.close();
-		shanghaiInfo.close();
-		beijingInfo.close();
-		taipeiInfo.close();
-		iomInfo.close();
-		japanInfo.close();
-	    bostonInfo.open(map,boston);
-	});
-	google.maps.event.addListener(shanghai, 'click', function() {
-		bostonInfo.close();
-		londonInfo.close();
-		beijingInfo.close();
-		taipeiInfo.close();
-		iomInfo.close();
-		japanInfo.close();
-	    shanghaiInfo.open(map,shanghai);
-	});
-	google.maps.event.addListener(beijing, 'click', function() {
-		bostonInfo.close();
-		shanghaiInfo.close();
-		londonInfo.close();
-		taipeiInfo.close();
-		iomInfo.close();
-		japanInfo.close();
-	    beijingInfo.open(map,beijing);
-	});
-	google.maps.event.addListener(taipei, 'click', function() {
-		bostonInfo.close();
-		shanghaiInfo.close();
-		beijingInfo.close();
-		londonInfo.close();
-		iomInfo.close();
-		japanInfo.close();
-	    taipeiInfo.open(map,taipei);
-	});
-	google.maps.event.addListener(iom, 'click', function() {
-		bostonInfo.close();
-		shanghaiInfo.close();
-		beijingInfo.close();
-		taipeiInfo.close();
-		londonInfo.close();
-		japanInfo.close();
-	    iomInfo.open(map,iom);
-	});
-	google.maps.event.addListener(japan, 'click', function() {
-		bostonInfo.close();
-		shanghaiInfo.close();
-		beijingInfo.close();
-		taipeiInfo.close();
-		londonInfo.close();
-		iomInfo.close();
-	    japanInfo.open(map,japan);
-	});
+  google.maps.event.addListener(london, 'click', function() {
+    bostonInfo.close();
+    shanghaiInfo.close();
+    beijingInfo.close();
+    taipeiInfo.close();
+    iomInfo.close();
+    japanInfo.close();
+      londonInfo.open(map,london);
+  });
+  google.maps.event.addListener(boston, 'click', function() {
+    londonInfo.close();
+    shanghaiInfo.close();
+    beijingInfo.close();
+    taipeiInfo.close();
+    iomInfo.close();
+    japanInfo.close();
+      bostonInfo.open(map,boston);
+  });
+  google.maps.event.addListener(shanghai, 'click', function() {
+    bostonInfo.close();
+    londonInfo.close();
+    beijingInfo.close();
+    taipeiInfo.close();
+    iomInfo.close();
+    japanInfo.close();
+      shanghaiInfo.open(map,shanghai);
+  });
+  google.maps.event.addListener(beijing, 'click', function() {
+    bostonInfo.close();
+    shanghaiInfo.close();
+    londonInfo.close();
+    taipeiInfo.close();
+    iomInfo.close();
+    japanInfo.close();
+      beijingInfo.open(map,beijing);
+  });
+  google.maps.event.addListener(taipei, 'click', function() {
+    bostonInfo.close();
+    shanghaiInfo.close();
+    beijingInfo.close();
+    londonInfo.close();
+    iomInfo.close();
+    japanInfo.close();
+      taipeiInfo.open(map,taipei);
+  });
+  google.maps.event.addListener(iom, 'click', function() {
+    bostonInfo.close();
+    shanghaiInfo.close();
+    beijingInfo.close();
+    taipeiInfo.close();
+    londonInfo.close();
+    japanInfo.close();
+      iomInfo.open(map,iom);
+  });
+  google.maps.event.addListener(japan, 'click', function() {
+    bostonInfo.close();
+    shanghaiInfo.close();
+    beijingInfo.close();
+    taipeiInfo.close();
+    londonInfo.close();
+    iomInfo.close();
+      japanInfo.open(map,japan);
+  });
 
 }
 
@@ -414,212 +414,201 @@ google.maps.event.addDomListener(window, 'load', initialize);
 </script>
 <div class="wrapper">
 <div class="map-address row">
-	<h2 class="icon-location">Where we are</h2>
-	<p>We have staff in over 30 countries and offices in seven locations.</p>
+  <h2 class="icon-location">Where we are</h2>
+  <p>We have staff in over 30 countries and offices in seven locations.</p>
 
-	<div itemprop="address" class="tabbed-content panel hide address" itemscope itemtype="http://schema.org/PostalAddress">
-		<a class="accordion-button slideless" href="#">London, United Kingdom</a>
-		<div>
-			<h3 class="title">London, United Kingdom</h3>
-			<p>Canonical Group Limited<br />
-			<span itemprop="streetAddress">5th Floor, Blue Fin Building</span><br />
-			<span itemprop="streetAddress">110 Southwark Street</span><br />
-			<span itemprop="addressRegion">London</span>, <span itemprop="postalCode">SE1 0SU</span><br />
-			<span itemprop="addressCountry">United Kingdom</span><br />
-			<a href="https://maps.google.co.uk/maps?q=5th+Floor,+Blue+Fin+Building+110+Southwark+Street+London,+SE1+0SU+United+Kingdom&amp;hl=en&amp;sll=52.8382,-2.327815&amp;sspn=7.78157,20.43457&amp;hnear=Blue+Fin+Bldg,+110+Southwark+St,+London+SE1+0SU,+United+Kingdom&amp;t=m&amp;z=16">View map &rsaquo;</a></p>
-		</div>
-	</div><!-- /address -->
+  <div itemprop="address" class="tabbed-content panel hide address" itemscope itemtype="http://schema.org/PostalAddress">
+    <a class="accordion-button slideless" href="#">London, United Kingdom</a>
+    <div>
+      <h3 class="title">London, United Kingdom</h3>
+      <p>Canonical Group Limited<br />
+      <span itemprop="streetAddress">5th Floor, Blue Fin Building</span><br />
+      <span itemprop="streetAddress">110 Southwark Street</span><br />
+      <span itemprop="addressRegion">London</span>, <span itemprop="postalCode">SE1 0SU</span><br />
+      <span itemprop="addressCountry">United Kingdom</span><br />
+      <a href="https://maps.google.co.uk/maps?q=5th+Floor,+Blue+Fin+Building+110+Southwark+Street+London,+SE1+0SU+United+Kingdom&amp;hl=en&amp;sll=52.8382,-2.327815&amp;sspn=7.78157,20.43457&amp;hnear=Blue+Fin+Bldg,+110+Southwark+St,+London+SE1+0SU,+United+Kingdom&amp;t=m&amp;z=16">View map &rsaquo;</a></p>
+    </div>
+  </div><!-- /address -->
 
-	<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
-		<a class="accordion-button slideless" href="#">Boston, United States</a>
-		<div>
-			<h3 class="title">Boston, United States</h3>
-			<p>Canonical USA Inc.<br />
-			<span itemprop="streetAddress">Suite 212 Lexington Corporate Center</span><br />
-			<span itemprop="streetAddress">10 Maguire Road</span><br />
-			<span itemprop="addressRegion">Lexington</span>, <span itemprop="postalCode">MA 02421</span><br />
-			<span itemprop="addressCountry">United States of America</span><br />
-			<a href="https://maps.google.co.uk/maps?q=10+Maguire+Rd,+Lexington,+MA,+USA&amp;hl=en&amp;sll=42.510443,-71.260566&amp;sspn=1.186442,2.554321&amp;hnear=10+Maguire+Rd,+Lexington,+Massachusetts+02421,+United+States&amp;t=m&amp;z=16">View map &rsaquo;</a></p>
-		</div>
-	</div><!-- /address -->
+  <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
+    <a class="accordion-button slideless" href="#">Boston, United States</a>
+    <div>
+      <h3 class="title">Boston, United States</h3>
+      <p>Canonical USA Inc.<br />
+      <span itemprop="streetAddress">Suite 212 Lexington Corporate Center</span><br />
+      <span itemprop="streetAddress">10 Maguire Road</span><br />
+      <span itemprop="addressRegion">Lexington</span>, <span itemprop="postalCode">MA 02421</span><br />
+      <span itemprop="addressCountry">United States of America</span><br />
+      <a href="https://maps.google.co.uk/maps?q=10+Maguire+Rd,+Lexington,+MA,+USA&amp;hl=en&amp;sll=42.510443,-71.260566&amp;sspn=1.186442,2.554321&amp;hnear=10+Maguire+Rd,+Lexington,+Massachusetts+02421,+United+States&amp;t=m&amp;z=16">View map &rsaquo;</a></p>
+    </div>
+  </div><!-- /address -->
 
-	<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
-		<a class="accordion-button slideless" href="#">Shanghai, China</a>
-		<div>
-			<h3 class="title">Shanghai, China</h3>
-			<p itemprop="streetAddress">Room 1246, 12F<br />
-			<span itemprop="streetAddress">No. 331 North Caoxi Road</span><br />
-			<span itemprop="addressRegion">Shanghai 200031</span><br />
-			<span itemprop="addressCountry">China</span><br />
-			<span itemprop="postalCode">上海市漕溪北路331号12楼1246室 200031</span><br />
-			<a href="https://www.google.co.uk/maps/place/331+Cao+Xi+Bei+Lu/@31.1905161,121.4378999,16z/data=!4m2!3m1!1s0x35b26531db361fd5:0xac20ddade60d18cd">View map &rsaquo;</a></p>
-		</div>
-	</div><!-- /address -->
+  <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
+    <a class="accordion-button slideless" href="#">Shanghai, China</a>
+    <div>
+      <h3 class="title">Shanghai, China</h3>
+      <p itemprop="streetAddress">Room 1246, 12F<br />
+      <span itemprop="streetAddress">No. 331 North Caoxi Road</span><br />
+      <span itemprop="addressRegion">Shanghai 200031</span><br />
+      <span itemprop="addressCountry">China</span><br />
+      <span itemprop="postalCode">上海市漕溪北路331号12楼1246室 200031</span><br />
+      <a href="https://www.google.co.uk/maps/place/331+Cao+Xi+Bei+Lu/@31.1905161,121.4378999,16z/data=!4m2!3m1!1s0x35b26531db361fd5:0xac20ddade60d18cd">View map &rsaquo;</a></p>
+    </div>
+  </div><!-- /address -->
 
-	<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
-		<a class="accordion-button slideless" href="#">Beijing, China</a>
-		<div>
-			<h3 class="title">Beijing, China</h3>
-			<p itemprop="streetAddress">Room 17- 01Z, Floor B17, 101 Nei, Floor 3- 24<br />
-			<span itemprop="streetAddress">No. 3, Xinyuan South Road, Chaoyang District</span><br />
-			<span itemprop="addressRegion">Beijing P.R.C. 100027</span><br />
-			<span itemprop="addressCountry">China</span><br />
-			<span itemprop="postalCode">北京市朝阳区新源南路3号- 3至24层101内B17层17- 01Z室 100027</span><br />
-			<a href="https://www.google.co.uk/maps/place/Gucci/@39.940926,116.447657,16z/data=!4m2!3m1!1s0x35f1ac96a16515c9:0x7746eb837ea0f8cc">View map &rsaquo;</a></p>
-		</div>
-	</div><!-- /address -->
+  <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
+    <a class="accordion-button slideless" href="#">Beijing, China</a>
+    <div>
+      <h3 class="title">Beijing, China</h3>
+      <p itemprop="streetAddress">Room 17- 01Z, Floor B17, 101 Nei, Floor 3- 24<br />
+      <span itemprop="streetAddress">No. 3, Xinyuan South Road, Chaoyang District</span><br />
+      <span itemprop="addressRegion">Beijing P.R.C. 100027</span><br />
+      <span itemprop="addressCountry">China</span><br />
+      <span itemprop="postalCode">北京市朝阳区新源南路3号- 3至24层101内B17层17- 01Z室 100027</span><br />
+      <a href="https://www.google.co.uk/maps/place/Gucci/@39.940926,116.447657,16z/data=!4m2!3m1!1s0x35f1ac96a16515c9:0x7746eb837ea0f8cc">View map &rsaquo;</a></p>
+    </div>
+  </div><!-- /address -->
 
 
-	<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
-		<a class="accordion-button slideless" href="#">Taipei, Taiwan</a>
-		<div>
-			<h3 class="title">Taipei, Taiwan</h3>
-			<p>Canonical Limited Taiwan Branch<br />
-			<span itemprop="streetAddress">Room D, 46F,</span><br />
-			<span itemprop="streetAddress">No. 7, Xin Yi Rd., Sec.5,</span><br />
-			<span itemprop="addressLocality">Taipei 101</span><br />
-			<span itemprop="addressCountry">Taiwan</span><br />
-			<a href="https://maps.google.co.uk/maps?q=Taipei+101+Taiwan&amp;hl=en&amp;ll=25.033622,121.565008&amp;spn=0.022786,0.039911&amp;sll=25.037238,121.563892&amp;sspn=0.091141,0.159645&amp;hnear=Taipei+101,+Taiwan&amp;t=m&amp;z=15">View map &rsaquo;</a></p>
-		</div>
-	</div><!-- /address -->
+  <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
+    <a class="accordion-button slideless" href="#">Taipei, Taiwan</a>
+    <div>
+      <h3 class="title">Taipei, Taiwan</h3>
+      <p>Canonical Limited Taiwan Branch<br />
+      <span itemprop="streetAddress">Room D, 46F,</span><br />
+      <span itemprop="streetAddress">No. 7, Xin Yi Rd., Sec.5,</span><br />
+      <span itemprop="addressLocality">Taipei 101</span><br />
+      <span itemprop="addressCountry">Taiwan</span><br />
+      <a href="https://maps.google.co.uk/maps?q=Taipei+101+Taiwan&amp;hl=en&amp;ll=25.033622,121.565008&amp;spn=0.022786,0.039911&amp;sll=25.037238,121.563892&amp;sspn=0.091141,0.159645&amp;hnear=Taipei+101,+Taiwan&amp;t=m&amp;z=15">View map &rsaquo;</a></p>
+    </div>
+  </div><!-- /address -->
 
-	<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
-		<a class="accordion-button slideless" href="#">Isle of Man</a>
-		<div>
-			<h3 class="title">Isle of Man</h3>
-			<p>Canonical Limited<br />
-			<span itemprop="streetAddress">One Circular Road</span><br />
-			<span itemprop="addressLocality">Douglas</span><br />
-			<span itemprop="addressCountry">Isle of Man</span><br />
-			<span itemprop="postalCode">IM1 1SB</span><br />
-			<a href="https://maps.google.co.uk/maps?q=1+Circular+Road,+IM1+1SB&amp;hl=en&amp;ll=54.151012,-4.483538&amp;spn=0.007364,0.019956&amp;sll=54.15272,-4.487221&amp;sspn=0.007364,0.019956&amp;hnear=1+Circular+Rd,+Isle+of+Man&amp;t=m&amp;z=16">View map &rsaquo;</a></p>
-		</div>
-	</div><!-- /address -->
+  <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content panel hide address">
+    <a class="accordion-button slideless" href="#">Isle of Man</a>
+    <div>
+      <h3 class="title">Isle of Man</h3>
+      <p>Canonical Limited<br />
+      <span itemprop="streetAddress">One Circular Road</span><br />
+      <span itemprop="addressLocality">Douglas</span><br />
+      <span itemprop="addressCountry">Isle of Man</span><br />
+      <span itemprop="postalCode">IM1 1SB</span><br />
+      <a href="https://maps.google.co.uk/maps?q=1+Circular+Road,+IM1+1SB&amp;hl=en&amp;ll=54.151012,-4.483538&amp;spn=0.007364,0.019956&amp;sll=54.15272,-4.487221&amp;sspn=0.007364,0.019956&amp;hnear=1+Circular+Rd,+Isle+of+Man&amp;t=m&amp;z=16">View map &rsaquo;</a></p>
+    </div>
+  </div><!-- /address -->
 </div><!-- /map-address -->
 
 <div id="contact-row" class="row">
-	<div class="inner-wrapper">
-		<div class="four-col">
-			<blockquote class="quote quote-left-bottom">
-				<h2 class="icon-quote">Contact us</h2>
-			</blockquote>
-		</div><!-- /col -->
-		<div class="four-col">
-			<h3>Customer enquiries</h3>
-			<p>To talk to us about our management, consulting or support services, <a href="services/contact-us">contact the sales team</a>.</p>
+  <div class="inner-wrapper">
+    <div class="four-col">
+      <blockquote class="quote quote-left-bottom">
+        <h2 class="icon-quote">Contact us</h2>
+      </blockquote>
+    </div><!-- /col -->
+    <div class="four-col">
+      <h3>Customer enquiries</h3>
+      <p>To talk to us about our management, consulting or support services, <a href="services/contact-us">contact the sales team</a>.</p>
 
-			<h3>Partnering enquiries</h3>
-			<p>To find out more about becoming a partner, <a href="/partners/contact-us">contact the partnership team</a>.</p>
-		</div><!-- /col -->
-		<div class="four-col last-col">
-			<h3>Media enquiries</h3>
-			<p>Journalists and analysts seeking information should email <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
+      <h3>Partnering enquiries</h3>
+      <p>To find out more about becoming a partner, <a href="/partners/contact-us">contact the partnership team</a>.</p>
+    </div><!-- /col -->
+    <div class="four-col last-col">
+      <h3>Media enquiries</h3>
+      <p>Journalists and analysts seeking information should email <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
 
-			<h3>Telephone enquiries</h3>
-			<p>Our main switchboard number is +44&nbsp;20&nbsp;7630&nbsp;2400.</p>
-		</div><!-- /col -->
-	</div><!-- /inner-wrapper -->
+      <h3>Telephone enquiries</h3>
+      <p>Our main switchboard number is +44&nbsp;20&nbsp;7630&nbsp;2400.</p>
+    </div><!-- /col -->
+  </div><!-- /inner-wrapper -->
 </div><!-- /row -->
 
-	<div class="row strip-light">
-		<div class="inner-wrapper">
-			<div class="twelve-col">
-				<h2>Further information</h2>
-			</div>
-		<div class="four-col">
-			<h3><a href="https://insights.ubuntu.com/topics/news/" class="further-news">News &rsaquo;</a></h3>
-			<div><ul class="no-bullets" id="news-feed"><noscript><li><a href="https://insights.ubuntu.com/topics/news/" title="go the Press centre on the Ubuntu insights" class="external">See all our Press centre on Ubuntu insights</a></li></noscript></ul></div>
-		</div>
-		<div class="four-col">
-			<h3><a href="https://insights.ubuntu.com/" class="further-resources">Resources &rsaquo;</a></h3>
-			<div><ul class="no-bullets" id="resources-feed"><noscript><li><a href="//insights.ubuntu.com" title="go the Ubuntu insights blog" class="external">See all our white papers, case studies and fact-sheets on Ubuntu insights</a></li></noscript></ul></div>
+  <div class="row strip-light">
+    <div class="inner-wrapper">
+      <div class="twelve-col">
+        <h2>Further information</h2>
+      </div>
+    <div class="four-col">
+      <h3><a href="https://insights.ubuntu.com/topics/news/" class="further-news">News &rsaquo;</a></h3>
+      <div><ul class="no-bullets" id="news-feed"><noscript><li><a href="https://insights.ubuntu.com/topics/news/" title="go the Press centre on the Ubuntu insights" class="external">See all our Press centre on Ubuntu insights</a></li></noscript></ul></div>
+    </div>
+    <div class="four-col">
+      <h3><a href="https://insights.ubuntu.com/" class="further-resources">Resources &rsaquo;</a></h3>
+      <div><ul class="no-bullets" id="resources-feed"><noscript><li><a href="//insights.ubuntu.com" title="go the Ubuntu insights blog" class="external">See all our white papers, case studies and fact-sheets on Ubuntu insights</a></li></noscript></ul></div>
+      </div> <!-- prm /col -->
+      <div class="four-col last-col">
+        <h3><a href="http://community.ubuntu.com" class="further-community">Community &rsaquo;</a></h3>
+        <p>There are many ways you can contribute to Ubuntu, either as an individual user or an organisation. </p>
+        <h3><a href="http://blog.canonical.com/" class="further-blog">Canonical Blog&nbsp;&rsaquo;</a></h3>
+        <p>On the Canonical blog, you&rsquo;ll find detailed analysis and personal viewpoints on Canonical announcements.</p>
+      </div>
 
-<script>
+    </div><!-- /inner-wrapper -->
+  </div><!-- /row -->
 
-// this script gets news and resources from insights.ubuntu.com
+  <div class="row row-contextual-footer">
+    <div class="inner-wrapper vertical-divider">
+      <div class="featured six-col canonical-icon">
+        <h3><a href="/services/contact-us">Contact us about services&nbsp;&rsaquo;</a></h3>
+        <p>Interested in Ubuntu Advantage? Talk to us about our management services and consultancy.</p>
+      </div><!-- /col -->
+      <div class="three-col">
+        <h3><a href="/partners/contact-us">Contact us about partnerships&nbsp;&rsaquo;</a></h3>
+        <p>Interested in becoming a partner? Talk to us today for more information about our services and certification.</p>
+      </div><!-- /col -->
+      <div class="three-col last-col">
+        <p>Media or analysts seeking press information or interviews should email <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
+      </div><!-- /col -->
+    </div><!-- /inner-wrapper -->
+  </div><!-- /row -->
 
-var html_id = "";
-
-function get_insights_list(url, limit, html_id, type) {
-
-	var container = document.getElementById(html_id);
-	var monthNames = [ "January", "February", "March", "April", "May", "June",
-						"July", "August", "September", "October", "November", "December" ];
-
-	feed = new google.feeds.Feed(url);          // gets the feed
-	feed.setNumEntries(limit);                      // set the number of articles you want back
-	feed.load(format_feed);							// get the feed
-
-	function format_feed(result) {
-
-		var output = "";
-
-		if (!result.error) {
-
-			var entries = result.feed.entries;
-
-			for (var i = 0; i < entries.length; i++) {
-
-				if (type == "cat") {
-					// format for category display
-					var cat = entries[i].categories[0];
-					output = "<a href='" + entries[i].link + "'>" + entries[i].title + "&nbsp;&rsaquo;</a><p class='note'>" + cat + "</p>";
-
-				} else {
-					// format with a date - default
-					var date = new Date(entries[i].publishedDate);
-					output = "<a href='" + entries[i].link + "'>" + entries[i].title + "&nbsp;&rsaquo;</a><p class='note'>" + date.getDay() + " " + monthNames[date.getMonth()] + " " + date.getFullYear() + "</p>";
-
-				}
-
-				var list = document.createElement("li");
-				list.insertAdjacentHTML('beforeend', output);
-				container.appendChild(list);
-			}
-		}
-	} // end function format_feed
-} // end function get_insights_list
-
-function OnLoad() {
-	// news list
-	output = "";
-	get_insights_list("https://insights.ubuntu.com/category/news/feed/", 3, "news-feed", "date");
-
-	// resources list
-	output = "";
-	get_insights_list("https://insights.ubuntu.com/category/factsheets/feed/", 1, "resources-feed", "cat");
-	get_insights_list("https://insights.ubuntu.com/category/white-papers/feed/", 1, "resources-feed", "cat");
-	get_insights_list("https://insights.ubuntu.com/category/case-studies/feed/", 1, "resources-feed", "cat");
-
-}
-google.setOnLoadCallback(OnLoad);
-
-</script>
-
-			</div> <!-- prm /col -->
-			<div class="four-col last-col">
-				<h3><a href="http://community.ubuntu.com" class="further-community">Community &rsaquo;</a></h3>
-				<p>There are many ways you can contribute to Ubuntu, either as an individual user or an organisation. </p>
-				<h3><a href="http://blog.canonical.com/" class="further-blog">Canonical Blog&nbsp;&rsaquo;</a></h3>
-				<p>On the Canonical blog, you&rsquo;ll find detailed analysis and personal viewpoints on Canonical announcements.</p>
-			</div>
-
-		</div><!-- /inner-wrapper -->
-	</div><!-- /row -->
-
-	<div class="row row-contextual-footer">
-		<div class="inner-wrapper vertical-divider">
-			<div class="featured six-col canonical-icon">
-				<h3><a href="/services/contact-us">Contact us about services&nbsp;&rsaquo;</a></h3>
-				<p>Interested in Ubuntu Advantage? Talk to us about our management services and consultancy.</p>
-			</div><!-- /col -->
-			<div class="three-col">
-				<h3><a href="/partners/contact-us">Contact us about partnerships&nbsp;&rsaquo;</a></h3>
-				<p>Interested in becoming a partner? Talk to us today for more information about our services and certification.</p>
-			</div><!-- /col -->
-			<div class="three-col last-col">
-				<p>Media or analysts seeking press information or interviews should email <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
-			</div><!-- /col -->
-		</div><!-- /inner-wrapper -->
-	</div><!-- /row -->
+  <!-- script to get news, white papers and case studies -->
+  <script type="text/javascript">
+    /* News */
+    $(function() {
+      $.getFeed({
+        url: 'https://insights.ubuntu.com/category/news/feed/',
+        success: function(feed) {
+          var html = "";
+          for(var i = 0; i < feed.items.length && i < 4; i++) {
+            var item = feed.items[i];
+            html += "<li><a href='" + item.link + "'>" + item.title + "</a><p class='note'><time pubdate datetime='" + item.updated + "'>" + item.nicedate + "</time></p></li>";
+          }
+          if ($('#news-feed')) {
+            $('#news-feed').append(html);
+          }
+        }
+      });
+    });
+    /* Whitepapers */
+    $(function() {
+      $.getFeed({
+        url: 'https://insights.ubuntu.com/category/white-papers/feed/',
+        success: function(feed) {
+          var html = "";
+          for(var i = 0; i < feed.items.length && i < 2; i++) {
+            var item = feed.items[i];
+            html += "<li><a href='" + item.link + "'>" + item.title + "</a><p class='note'>" + item.category + "</p></li>";
+          }
+          if ($('#resources-feed')) {
+            $('#resources-feed').append(html);
+          }
+        }
+      });
+    });
+    /* Case studies */
+    $(function() {
+      $.getFeed({
+        url: 'https://insights.ubuntu.com/category/case-studies/feed/',
+        success: function(feed) {
+          var html = "";
+          for(var i = 0; i < feed.items.length && i < 2; i++) {
+            var item = feed.items[i];
+            html += "<li><a href='" + item.link + "'>" + item.title + "</a><p class='note'>" + item.category + "</p></li>";
+          }
+          if ($('#resources-feed')) {
+            $('#resources-feed').append(html);
+          }
+        }
+      });
+    });
+  </script>
 {% endblock content %}


### PR DESCRIPTION
# Details
- card: https://trello.com/c/QxTSBfNG
## done
- removed the old google feed api code and replaced it with the newer jquery version
- also removed factsheets as they aren't on insights any more
## qa
-  go to www.canonical.com/cloud and see that the news and resources block have articles just like the live website (only you cannot as the feeds are CORs blocked, you could use test feeds from http://www.stmgrts.org.uk/taleo/)
