### PR TITLE
remove Rick Spencer from the management team list

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -86,7 +86,6 @@
           <li><a class="active slideless" href="#jane-silber">Jane Silber</a></li>
           <li><a class="slideless" href="#mark-shuttleworth">Mark Shuttleworth</a></li>
           <li><a class="slideless" href="#anand-krishnan">Anand Krishnan</a></li>
-          <li><a class="slideless" href="#rick-spencer">Rick Spencer</a></li>
           <li><a class="slideless" href="#robbie-williamson">Robbie Williamson</a></li>
           <li><a class="slideless" href="#chris-kenyon">Chris Kenyon</a></li>
           <li><a class="slideless" href="#neil-french">Neil French</a></li>
@@ -152,26 +151,6 @@
         </div><!-- /col -->
       </div><!-- /col -->
     </div><!-- /person -->
-    <div id="rick-spencer" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
-      <a class="accordion-button slideless" href="#rick-spencer">Rick Spencer</a>
-      <div class="nine-col">
-        <div class="five-col">
-          <div class="clearfix">
-            <img itemprop="image" class="portrait" src="{{ ASSET_SERVER_URL }}f3b22374-rick-spencer.png" alt="" />
-            <h3 itemprop="name">Rick Spencer</h3>
-            <p itemprop="jobTitle" class="role">VP, Ubuntu Engineering</p>
-          </div>
-          <p itemprop="description">Rick leads the team responsible for Canonical&rsquo;s numerous engineering contributions to Ubuntu. Before joining the company, he spent many years in software development, including almost a decade in developer experience and management roles at Microsoft. </p>
-          <p><a href="http://theravingrick.blogspot.co.uk/" class="external">Read Rick&rsquo;s blog</a></p>
-          <p><a href="https://twitter.com/rickspencer3" class="external">Follow Rick on Twitter</a></p>
-        </div>
-        <div class="four-col last-col">
-          <blockquote class="pull-quote">
-            <p><span>&ldquo;</span>Through a unique combination of stellar people, engaged community, strong principles, and ever improving technology, I believe Ubuntu will make the world a better place.<span>&rdquo;</span></p>
-          </blockquote>
-        </div>
-      </div>
-    </div>
     <div id="robbie-williamson" class="tabbed-content panel nine-col last-col hide" itemscope itemtype="http://schema.org/Person">
       <a class="accordion-button slideless" href="#robbie-williamson">Robbie Williamson</a>
       <div class="nine-col">


### PR DESCRIPTION
### Done

Removed refs to Rick Spencer on the about page
### QA

`make run`
Navigate to /about and see that Rick no longer features on the management team list.
