### PR TITLE
Correct /services 404 link to Insights case study

### DIFF
--- a/templates/services/index.html
+++ b/templates/services/index.html
@@ -95,37 +95,6 @@
                 <h3><a class="external" href="https://insights.ubuntu.com/2014/03/25/an-ubuntu-pc-for-everyone-in-penn-manor-school-district-pennsylvania-usa/">View case study&nbsp;</a></h3>
                 <p>An Ubuntu PC for everyone in Penn Manor School District, Pennsylvania, USA.</p>
             </div>
-            <!--<div id="resources-feed"></div>
-            <script>
-            var rssoutput = "";
-            var feedcontainer2 = document.getElementById("resources-feed");
-            var feeds = new Array("http://insights.ubuntu.com/topics/case-studies/feed/");
-
-            function rssfeedsetup2(feedURL) {
-            var feedpointer2 = new google.feeds.Feed(feedURL); //Google Feed API method
-            feedpointer2.setNumEntries(1); //Google Feed API method
-            feedpointer2.load(displayfeed2); //Google Feed API method
-            }
-
-            function displayfeed2(result) {
-            if (!result.error) {
-            var thefeeds2 = result.feed.entries;
-            for (var i = 0; i < thefeeds2.length; i++) {
-            var cat = thefeeds2[i].categories[0];
-            rssoutput += "<h3><a class='external' href='" + thefeeds2[i].link + "'>" + "View case study" + "&nbsp;</a>" + "</h3>";
-            rssoutput += "<p>" + thefeeds2[i].title + ".</p>";
-            }
-            feedcontainer2.innerHTML = rssoutput;
-            }
-            }
-
-            window.onload = function() {
-            var i = feeds.length;
-            while(i--) {
-            rssfeedsetup2(feeds[i]);
-            }
-            }
-            </script>-->
         </div>
         <div class="three-col last-col">
             <h3><a href="/services/contact-us">Contact us today &rsaquo;</a></h3>


### PR DESCRIPTION
## Done
- Corrected a link to insights that was resulting in a 404
- Removed redundant commented-out code
## QA
- Navigate to /services
- Scroll down to contextual footer
- Click 'View Case Study'
- Ensure this link goes through to relevant page on insights
## Trello

https://trello.com/c/jrikrpGj
