### PR TITLE
Add simple vacancy page and form

### DIFF
--- a/templates/careers/vacancies.html
+++ b/templates/careers/vacancies.html
@@ -1,0 +1,28 @@
+{% extends "careers/base_careers.html" %}
+
+{% block title %}Canonical | Careers | All current vacancies{% endblock %}
+{% block meta_description %}If you’re interested in open source software, the cloud or mobile devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
+{% block meta_keywords %}Canonical, Ubuntu, Linux, open source, free, software, design, designer, development, developer, programmer, engineer, UX, user, experience, interface, technology, IT, job, career, work, vacancy, vacancies, London, Taipei, Montreal, Boston, Shanghai, work from home, working from home, cloud, phone, smartphone, mobile{% endblock %}
+{% block head_extra %}
+	<script src="//www.google.com/jsapi"></script>
+	<script>google.load("feeds", "1");</script>
+{% endblock %}
+
+{% block content %}
+<div class="strip row">
+	<div class="inner-wrapper">
+		<div class="eight-col">
+			<p>
+				<a href="{% url 'vacancies' %}">Example vacancies link</a>
+			</p>
+			<p>
+	            <form action="" method="post">
+	                {{ form }}
+	                <input type="submit" value="Submit" />
+	            </form>
+			</p>
+		</div>
+	</div>
+</div>
+
+{% endblock content %}

--- a/webapp/forms.py
+++ b/webapp/forms.py
@@ -1,0 +1,40 @@
+from django import forms
+
+from webapp.lib import vacancies
+
+
+class VacanciesFilterForm(forms.Form):
+    continents = forms.MultipleChoiceField(
+        label='Geographical area',
+        choices=sorted(vacancies.CONTINENTS),
+        widget=forms.CheckboxSelectMultiple(),
+        required=False,
+    )
+    location = forms.MultipleChoiceField(
+        label='Location',
+        choices=sorted(vacancies.LOCATION),
+        widget=forms.CheckboxSelectMultiple(),
+        required=False,
+    )
+    contract = forms.MultipleChoiceField(
+        label='Contract type',
+        choices=sorted(vacancies.CONTRACTS),
+        widget=forms.CheckboxSelectMultiple(),
+        required=False,
+    )
+    discipline = forms.MultipleChoiceField(
+        label='Discipline',
+        choices=sorted(vacancies.DISCIPLINE),
+        widget=forms.CheckboxSelectMultiple(),
+        required=False,
+    )
+    job_title = forms.CharField(
+        label='Job title',
+        max_length=150,
+        required=False,
+    )
+    keyword = forms.CharField(
+        label='Keyword',
+        max_length=150,
+        required=False,
+    )

--- a/webapp/lib/vacancies.py
+++ b/webapp/lib/vacancies.py
@@ -1,0 +1,24 @@
+CONTINENTS = {
+    (('AF'), ('Africa')),
+    # (('AN'), ('Antarctica')),
+    (('AS'), ('Asia')),
+    (('EU'), ('Europe')),
+    (('NA'), ('North America')),
+    (('OC'), ('Oceania')),
+    (('SA'), ('South America')),
+}
+DISCIPLINE = {
+    (('operations'), ('Operations')),
+    (('design'), ('Design')),
+    (('sales'), ('Sales')),
+    (('marketing'), ('Marketing')),
+    (('engineering'), ('Engineering/Technology')),
+}
+LOCATION = {
+    (('office'), ('Office')),
+    (('home'), ('Home')),
+}
+CONTRACTS = {
+    (('permanent'), ('Permanent')),
+    (('contract'), ('Contract')),
+}

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -1,7 +1,13 @@
 from django.conf.urls import url
 from django_json_redirects import load_redirects
 from .views import CanonicalTemplateFinder
+from .views import VacanciesFilterView
 
 urlpatterns = load_redirects() + [
+    url(
+        r'^careers/vacancies$',
+        VacanciesFilterView.as_view(),
+        name='vacancies'
+    ),
     url(r'^(?P<template>.*)/?$', CanonicalTemplateFinder.as_view())
 ]

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -2,8 +2,11 @@
 Django views for www.canonical.com.
 """
 
+from django.shortcuts import render
+from django.views.generic.edit import FormView
 from django_template_finder_view import TemplateFinder
 
+from webapp.forms import VacanciesFilterForm
 
 class CanonicalTemplateFinder(TemplateFinder):
     """
@@ -26,3 +29,17 @@ class CanonicalTemplateFinder(TemplateFinder):
             context["level_" + str(index + 1)] = path
 
         return context
+
+
+class VacanciesFilterView(FormView):
+    form_class = VacanciesFilterForm
+    template_name = 'careers/vacancies.html'
+
+    def form_valid(self, form):
+        return render(
+            self.request, self.template_name, self.get_context_data()
+        )
+
+    def get(self, request, *args, **kwargs):
+        self.form = self.form_class(initial=request.GET)
+        return render(request, self.template_name, self.get_context_data())


### PR DESCRIPTION
Set up initial vacancies page for frontend work.

The functionality is currently very limited.

URL is set up to /careers/vacancies
