### PR TITLE
Update partners management image

### DIFF
--- a/static/css/section/_partners.scss
+++ b/static/css/section/_partners.scss
@@ -1,7 +1,7 @@
 // scss-lint:disable NestingDepth, SelectorDepth, QualifyingElement
 .partners {
   .row-management.strip-light {
-    background: url('https://assets.ubuntu.com/v1/0a6d514c-partners-hero-small.jpg') no-repeat center;
+    background: url('https://assets.ubuntu.com/v1/f43b5e66-mwc17-partners-hero.jpg?w=768') no-repeat center;
     background-size: cover;
     box-shadow: inset 0  4px 6px -4px rgba(0, 0, 0, .4), inset 0 -4px 6px -4px rgba(0, 0, 0, .4);
     height: 200px;
@@ -26,7 +26,7 @@
 @media only screen and (min-width : 768px) {
   .partners {
     .row-management.strip-light {
-      background-image: url('https://assets.ubuntu.com/v1/933baf0c-partners-hero-medium.jpg');
+      background-image: url('https://assets.ubuntu.com/v1/f43b5e66-mwc17-partners-hero.jpg?w=984');
       height: 350px;
     }
 
@@ -51,7 +51,7 @@
 
     .row-management.strip-light {
       background-color: $black;
-      background-image: url('https://assets.ubuntu.com/v1/6dbc4814-partners-hero.jpg');
+      background-image: url('https://assets.ubuntu.com/v1/f43b5e66-mwc17-partners-hero.jpg?q=80');
       background-position: 50% 50%;
       background-size: auto;
       height: 550px;


### PR DESCRIPTION
## Done
Update the partners image strip with a new MWC image

## QA
- Go to `/partners`
- Scroll to the MWC image strip
- Check the file size isn't too large (<200kb)
- Check the image scales with the screen width

## Details:
Fixes https://github.com/canonical-websites/www.canonical.com/issues/123

## Screenshot
![10526244](https://cloud.githubusercontent.com/assets/1413534/23963163/5c35f1be-09a8-11e7-95ad-8d689e1335d6.png)
