### PR TITLE
Remove mobile

### DIFF
--- a/static/css/section/_home.scss
+++ b/static/css/section/_home.scss
@@ -43,7 +43,7 @@
   }
 
   .ubuntu-row {
-    background: url('https://assets.ubuntu.com/v1/31a45631-desktop-enterprise-certified.jpg') no-repeat scroll 50% 97% rgba(255, 255, 255, 0.6);
+    background: url('https://assets.ubuntu.com/v1/fc4f2e49-desktop.png?w=600') no-repeat scroll 50% 97% rgba(255, 255, 255, 0.6);
     background-size: 350px auto;
     padding-bottom: 230px;
 
@@ -201,7 +201,7 @@ html.no-svg body.home {
       }
 
       .inner-wrapper:after {
-        background: url('https://assets.ubuntu.com/v1/57960a96-tablet-home.png') no-repeat;
+        background: url('https://assets.ubuntu.com/v1/fc4f2e49-desktop.png?w=865') no-repeat;
         content: " ";
         height: 569px;
         left: 45%;

--- a/static/css/section/_home.scss
+++ b/static/css/section/_home.scss
@@ -43,7 +43,7 @@
   }
 
   .ubuntu-row {
-    background: url('https://assets.ubuntu.com/v1/57960a96-tablet-home.png') no-repeat scroll 50% 97% rgba(255, 255, 255, 0.6);
+    background: url('https://assets.ubuntu.com/v1/31a45631-desktop-enterprise-certified.jpg') no-repeat scroll 50% 97% rgba(255, 255, 255, 0.6);
     background-size: 350px auto;
     padding-bottom: 230px;
 

--- a/static/css/section/_home.scss
+++ b/static/css/section/_home.scss
@@ -43,7 +43,7 @@
   }
 
   .ubuntu-row {
-    background: url('https://assets.ubuntu.com/v1/fc4f2e49-desktop.png?w=600') no-repeat scroll 50% 97% rgba(255, 255, 255, 0.6);
+    background: url('https://assets.ubuntu.com/v1/fc4f2e49-desktop.png?w=600') no-repeat scroll 50% 85% rgba(255, 255, 255, 0.6);
     background-size: 350px auto;
     padding-bottom: 230px;
 
@@ -206,7 +206,7 @@ html.no-svg body.home {
         height: 569px;
         left: 45%;
         position: absolute;
-        top: 20px;
+        top: 10%;
         width: 900px;
         z-index: 0;
       }

--- a/templates/careers/all-design-and-user-experience-vacancies.html
+++ b/templates/careers/all-design-and-user-experience-vacancies.html
@@ -1,7 +1,7 @@
 {% extends "careers/base_careers.html" %}
 
 {% block title %}Canonical | Careers | All Design and User Experience vacancies{% endblock %}
-{% block meta_description %}If you’re interested in open source software, the cloud or mobile devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
+{% block meta_description %}If you’re interested in open source software, the cloud or devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
 {% block meta_keywords %}Canonical, Ubuntu, Linux, open source, free, software, design, designer, development, developer, programmer, engineer, UX, user, experience, interface, technology, IT, job, career, work, vacancy, vacancies, London, Taipei, Montreal, Boston, Shanghai, work from home, working from home, cloud, phone, smartphone, mobile{% endblock %}
 
 {% block content %}

--- a/templates/careers/all-marketing-and-business-development-vacancies.html
+++ b/templates/careers/all-marketing-and-business-development-vacancies.html
@@ -1,7 +1,7 @@
 {% extends "careers/base_careers.html" %}
 
 {% block title %}Canonical | Careers | All Marketing and Business Development vacancies{% endblock %}
-{% block meta_description %}If you’re interested in open source software, the cloud or mobile devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
+{% block meta_description %}If you’re interested in open source software, the cloud or devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
 {% block meta_keywords %}Canonical, Ubuntu, Linux, open source, free, software, design, designer, development, developer, programmer, engineer, UX, user, experience, interface, technology, IT, job, career, work, vacancy, vacancies, London, Taipei, Montreal, Boston, Shanghai, work from home, working from home, cloud, phone, smartphone, mobile{% endblock %}
 
 {% block content %}

--- a/templates/careers/all-operations-vacancies.html
+++ b/templates/careers/all-operations-vacancies.html
@@ -1,7 +1,7 @@
 {% extends "careers/base_careers.html" %}
 
 {% block title %}Canonical | Careers | All Operations vacancies{% endblock %}
-{% block meta_description %}If you’re interested in open source software, the cloud or mobile devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
+{% block meta_description %}If you’re interested in open source software, the cloud or devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
 {% block meta_keywords %}Canonical, Ubuntu, Linux, open source, free, software, design, designer, development, developer, programmer, engineer, UX, user, experience, interface, technology, IT, job, career, work, vacancy, vacancies, London, Taipei, Montreal, Boston, Shanghai, work from home, working from home, cloud, phone, smartphone, mobile{% endblock %}
 
 {% block content %}

--- a/templates/careers/all-professional-services-vacancies.html
+++ b/templates/careers/all-professional-services-vacancies.html
@@ -1,7 +1,7 @@
 {% extends "careers/base_careers.html" %}
 
 {% block title %}Canonical | Careers | All Professional Services vacancies{% endblock %}
-{% block meta_description %}If you’re interested in open source software, the cloud or mobile devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
+{% block meta_description %}If you’re interested in open source software, the cloud or devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
 {% block meta_keywords %}Canonical, Ubuntu, Linux, open source, free, software, design, designer, development, developer, programmer, engineer, UX, user, experience, interface, technology, IT, job, career, work, vacancy, vacancies, London, Taipei, Montreal, Boston, Shanghai, work from home, working from home, cloud, phone, smartphone, mobile{% endblock %}
 
 {% block content %}

--- a/templates/careers/all-technical-and-engineering-vacancies.html
+++ b/templates/careers/all-technical-and-engineering-vacancies.html
@@ -1,7 +1,7 @@
 {% extends "careers/base_careers.html" %}
 
 {% block title %}Canonical | Careers | All Technical and Engineering vacancies{% endblock %}
-{% block meta_description %}If you’re interested in open source software, the cloud or mobile devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
+{% block meta_description %}If you’re interested in open source software, the cloud or devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
 {% block meta_keywords %}Canonical, Ubuntu, Linux, open source, free, software, design, designer, development, developer, programmer, engineer, UX, user, experience, interface, technology, IT, job, career, work, vacancy, vacancies, London, Taipei, Montreal, Boston, Shanghai, work from home, working from home, cloud, phone, smartphone, mobile{% endblock %}
 
 {% block content %}

--- a/templates/careers/all-vacancies.html
+++ b/templates/careers/all-vacancies.html
@@ -1,7 +1,7 @@
 {% extends "careers/base_careers.html" %}
 
 {% block title %}Canonical | Careers | All current vacancies{% endblock %}
-{% block meta_description %}If you’re interested in open source software, the cloud or mobile devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
+{% block meta_description %}If you’re interested in open source software, the cloud or devices, Canonical is an incredible place to work. Whether you’re a technologist, a designer or a business professional, opportunities exist to work from home or at one of our key offices around the world.{% endblock %}
 {% block meta_keywords %}Canonical, Ubuntu, Linux, open source, free, software, design, designer, development, developer, programmer, engineer, UX, user, experience, interface, technology, IT, job, career, work, vacancy, vacancies, London, Taipei, Montreal, Boston, Shanghai, work from home, working from home, cloud, phone, smartphone, mobile{% endblock %}
 
 {% block content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
 	<div class="inner-wrapper">
 		<div class="six-col">
 			<h2>We deliver <span class="ubuntu-logo">Ubuntu</span></h2>
-			<p>At the heart of everything we do is Ubuntu, an open source software platform that runs everywhere from the smartphone to the cloud. Our services ensure that it is certified for use on mobile devices, PCs, servers and cloud infrastructure &mdash; public or&nbsp;private.</p>
+			<p>At the heart of everything we do is Ubuntu, an open source software platform that runs everywhere from the Internet of Things to the cloud. Our services ensure that it is certified for use on devices, PCs, servers and cloud infrastructure &mdash; public or&nbsp;private.</p>
 			<p>On ubuntu.com, you&rsquo;ll find detailed information about the platform and its features, our services and management tools, plus details about our partner and certification&nbsp;programs.</p>
 			<p><a href="https://www.ubuntu.com" class="external">Learn more at ubuntu.com</a></p>
 		</div>

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -49,20 +49,21 @@
 
 <div class="row row-client strip-light">
 	<div class="inner-wrapper">
-		<h2 class="twelve-col">Ubuntu on the client</h2>
-		<div class="four-col">
-			<p>Canonical has a large, experienced OEM engagement team that has been closely involved with hardware makers like Dell, HP and Lenovo for many years. We provide a complete, end-to-end device delivery solution on Intel, AMD or ARM silicon, helping our partners identify market opportunities and deliver to market on time and on budget. Above all, we ensure a stunning experience on every device.</p>
+		<h2 class="twelve-col">Ubuntu IoT devices</h2>
+		<div class="six-col">
+			<p>Ubuntu is used on 100,000s of advertising screens and on robots across hospitality, retail and mining industries worldwide. Canonical collaborates with semiconductor and device manufacturers, making Ubuntu the number one platform for robotics and self-driving cars. Canonical also partners with device manufacturers across their product lifecycle: product concept, integration, development, ecosystem building and monetisation.</p>
 		</div>
-		<div class="eight-col last-col">
-			<img src="{{ ASSET_SERVER_URL }}abd6307b-image-laptop.png" alt="" />
+		<div class="six-col last-col">
+			<img src="{{ ASSET_SERVER_URL }}808a4e5b-aerolion-drone.png" alt="" />
 		</div>
 	</div>
 	<div class="inner-wrapper">
-		<div class="seven-col priority-0">
-			<img src="{{ ASSET_SERVER_URL }}201dd24c-image-phone-trio.png" alt="" />
+    <h2 class="six-col prepend-six">Ubuntu on the PC</h2>
+		<div class="six-col priority-0">
+			<img src="{{ ASSET_SERVER_URL }}abd6307b-image-laptop.png" alt="" />
 		</div>
-		<div class="five-col last-col">
-			<p>Thanks to Canonical&rsquo;s hardware enablement partnerships, Ubuntu is now pre-installed on laptops and desktops from the world&rsquo;s top brands in all major global markets. Ubuntu is also coming to the smartphone, with the specific needs of network operators, OEMs and ODMs in mind. It offers great performance on handsets with a low bill of materials, while opening up new opportunities for phone and PC convergence at the top end of the market.</p>
+		<div class="six-col last-col">
+			<p>Canonical has a large, experienced OEM engagement team that has been closely involved with hardware makers like Dell, HP and Lenovo for many years. We provide a complete, end-to-end device delivery solution on Intel, AMD or ARM silicon, helping our partners identify market opportunities and deliver to market on time and on budget. Thanks to Canonical&rsquo;s hardware enablement partnerships, Ubuntu is now pre-installed on industrial PCs, thin clients, laptops and desktops from the world&rsquo;s top brands in all major global markets.</p>
 			<p><a href="http://partners.ubuntu.com/find-a-partner?programme=technical-partner-programme" class="external">See all our hardware partners</a></p>
 		</div>
 	</div><!-- /.row -->
@@ -71,14 +72,14 @@
 <div class="row row-companies">
 	<div class="inner-wrapper">
 		<div class="panel panel--alt twelve-col">
-			<h2 class="muted-heading">A selection of our client partners</h2>
+			<h2 class="muted-heading">A selection of our IoT device and PC partners</h2>
 			{% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Technical Partner Programme" limit=10 as client_partners %}
 			<ul class="inline-logos no-bullets clear list-auto" id="client-logos">
 				{% for partner in client_partners %}
 				<li><img onload="this.style.opacity='1';" src="{{ partner.logo }}" alt="{{ partner.name }}"></li>
 				{% endfor %}
 			</ul>
-			<p class="align-center"><a href="http://partners.ubuntu.com/find-a-partner?technology=personal-computing/devices" class="external align-center">Browse all client partners</a></p>
+			<p class="align-center"><a href="http://partners.ubuntu.com/find-a-partner?technology=personal-computing/devices" class="external align-center">Browse all IoT device and PC partners</a></p>
 		</div>
 	</div>
 </div><!-- /.row -->

--- a/templates/products/index.html
+++ b/templates/products/index.html
@@ -106,7 +106,7 @@
 	        <p>Ubuntu is a single software platform that runs across smartphones, tablets, PCs, and TVs. It is designed to help make converged computing a reality&#58; one system, one experience, multiple form factors.</p>
 	    </div>
 	    <div class="twelve-col no-margin-bottom">
-	        <img src="{{ ASSET_SERVER_URL }}70089157-image-ontheclient.png" width="904" height="517" alt="Family of devices" />
+	        <img src="{{ ASSET_SERVER_URL }}bcb09a5b-desktop-features-smarter-searching.jpg" width="904" height="517" alt="Family of devices" />
 	    </div>
 	    <div class="eight-col">
 	        <p>Canonical works with most of the world&rsquo;s leading phone and PC makers, to certify Ubuntu for use on a huge range of devices. As a result, Ubuntu is now available on computers for sale in over 3,000 retailers across Mexico, China and India.</p>

--- a/templates/products/index.html
+++ b/templates/products/index.html
@@ -34,7 +34,7 @@
         </div>
     </div>
     <div class="six-col">
-        <p class="intro">Ubuntu is a platform that spans from the PC and the smartphone  to the server and the cloud. It includes a comprehensive suite of enterprise-grade tools for development, configuration, management and service&nbsp;orchestration. </p>
+        <p class="intro">Ubuntu is a platform that spans from the PC and IoT devices to the server and the cloud. It includes a comprehensive suite of enterprise-grade tools for development, configuration, management and service&nbsp;orchestration. </p>
         <p class="intro"><a href="https://www.ubuntu.com" class="external">Learn more on ubuntu.com</a></p>
     </div>
    </div>
@@ -46,7 +46,7 @@
         <ul class="connected-list">
             <li class="three-col">
                 <img src="{{ ASSET_SERVER_URL }}6daed065-icon-canonical.svg" class="icon" alt="">
-                <p>Canonical defines Ubuntu&rsquo;s strategy and drives innovation with a team of over 500 dedicated designers, developers and project&nbsp;managers.</p>
+                <p>Canonical defines Ubuntu&rsquo;s strategy and drives innovation with a team of over 400 dedicated designers, developers and project&nbsp;managers.</p>
             </li>
             <li class="three-col">
                 <img src="{{ ASSET_SERVER_URL }}b4a08b93-icon-calendar.svg" class="icon" alt="">
@@ -100,16 +100,18 @@
 <div class="row strip-light">
 	<div class="inner-wrapper">
 	    <div class="twelve-col">
-	        <h2>On the client&#58; multiple devices, one experience</h2>
+	        <h2>On the client&#58; devops for IoT</h2>
 	    </div>
 	    <div class="eight-col">
-	        <p>Ubuntu is a single software platform that runs across smartphones, tablets, PCs, and TVs. It is designed to help make converged computing a reality&#58; one system, one experience, multiple form factors.</p>
+        <p>Ubuntu is the preferred development environment for embedded engineers and widely used in <a href="https://www.ubuntu.com/internet-of-things">IoT devices</a> across verticals: automotive, industrial, robotics, networking and digital signage. Canonical works with semiconductors to make certified Ubuntu images that brings the best performance out of their hardware.</p>
+        <p>With snaps, the universal Linux packaging system, and <a href="https://snapcraft.io">snapcraft.io</a> developers a tool to build and distribute their software across multiple devices to facilitate the deployment of applications in production environments.</p>
+        <p>Ubuntu Core is the all snap version of Ubuntu, built for security.</p>
 	    </div>
 	    <div class="twelve-col no-margin-bottom">
-	        <img src="{{ ASSET_SERVER_URL }}bcb09a5b-desktop-features-smarter-searching.jpg" width="904" height="517" alt="Family of devices" />
+	        <img src="{{ ASSET_SERVER_URL }}ca8a41c4-desktop-enterprise-hero.png" width="904" height="517" alt="Family of devices" />
 	    </div>
 	    <div class="eight-col">
-	        <p>Canonical works with most of the world&rsquo;s leading phone and PC makers, to certify Ubuntu for use on a huge range of devices. As a result, Ubuntu is now available on computers for sale in over 3,000 retailers across Mexico, China and India.</p>
+	        <p>Canonical works with most of the world&rsquo;s leading device and PC makers, to certify Ubuntu for use on a huge range of systems. As a result, Ubuntu is now available on computers for sale in over 3,000 retailers across Mexico, China and India.</p>
 	    </div>
 	</div>
 </div>

--- a/templates/products/index.html
+++ b/templates/products/index.html
@@ -2,134 +2,133 @@
 
 {% block title %}Canonical | Products{% endblock %}
 {% block meta_description %}Canonical provides commercial services for Ubuntu’s users, while working with hardware manufacturers, software vendors and cloud partners to certify Ubuntu. {% endblock %}
-{% block meta_keywords %}Canonical, Ubuntu, open source, free, software, FOSS, Linux, operating system, OS, cloud, phone, smartphone, mobile, tablet, convergence, desktop, PC, server, service, commercial, support{% endblock %}
+{% block meta_keywords %}Canonical, Ubuntu, open source, free, software, FOSS, Linux, operating system, OS, cloud, phone, desktop, PC, server, service, commercial, support{% endblock %}
 
 {% block extra_body_class %}products-home{% endblock %}
 
 {% block content %}
 <div class="row row-hero">
-	<div class="inner-wrapper">
+  <div class="inner-wrapper">
     <div class="seven-col">
-        <h1>Ubuntu&#58; creating the world&rsquo;s best open source software platform</h1>
+      <h1>Ubuntu&#58; creating the world&rsquo;s best open source software platform</h1>
     </div>
     <div class="five-col last-col text-center">
-        <img src="{{ ASSET_SERVER_URL }}94be7baa-products-hero-small.png" alt="" />
-        <div class= "products-hero-container">
-            <div class= "products-hero-ubuntu"></div>
+      <img src="{{ ASSET_SERVER_URL }}94be7baa-products-hero-small.png" alt="" />
+      <div class= "products-hero-container">
+        <div class= "products-hero-ubuntu"></div>
 
-            <div class= "products-hero-desktop"></div>
-            <div class= "products-hero-line-1"></div>
+        <div class= "products-hero-desktop"></div>
+        <div class= "products-hero-line-1"></div>
 
-            <div class= "products-hero-phone"></div>
-            <div class= "products-hero-line-2"></div>
+        <div class= "products-hero-phone"></div>
+        <div class= "products-hero-line-2"></div>
 
-            <div class= "products-hero-tablet"></div>
-            <div class= "products-hero-line-3"></div>
+        <div class= "products-hero-tablet"></div>
+        <div class= "products-hero-line-3"></div>
 
-            <div class= "products-hero-server"></div>
-            <div class= "products-hero-line-4"></div>
+        <div class= "products-hero-server"></div>
+        <div class= "products-hero-line-4"></div>
 
-            <div class= "products-hero-cloud"></div>
-            <div class= "products-hero-line-5"></div>
-        </div>
+        <div class= "products-hero-cloud"></div>
+        <div class= "products-hero-line-5"></div>
+      </div>
     </div>
     <div class="six-col">
-        <p class="intro">Ubuntu is a platform that spans from the PC and IoT devices to the server and the cloud. It includes a comprehensive suite of enterprise-grade tools for development, configuration, management and service&nbsp;orchestration. </p>
-        <p class="intro"><a href="https://www.ubuntu.com" class="external">Learn more on ubuntu.com</a></p>
+      <p class="intro">Ubuntu is a platform that spans from the PC and IoT devices to the server and the cloud. It includes a comprehensive suite of enterprise-grade tools for development, configuration, management and service&nbsp;orchestration. </p>
+      <p class="intro"><a href="https://www.ubuntu.com" class="external">Learn more on ubuntu.com</a></p>
     </div>
-   </div>
+  </div>
 </div>
 
 <div class="row strip-dark">
-    <div class="inner-wrapper">
-		<h2>Canonical and Ubuntu</h2>
-        <ul class="connected-list">
-            <li class="three-col">
-                <img src="{{ ASSET_SERVER_URL }}6daed065-icon-canonical.svg" class="icon" alt="">
-                <p>Canonical defines Ubuntu&rsquo;s strategy and drives innovation with a team of over 400 dedicated designers, developers and project&nbsp;managers.</p>
-            </li>
-            <li class="three-col">
-                <img src="{{ ASSET_SERVER_URL }}b4a08b93-icon-calendar.svg" class="icon" alt="">
-                <p>Since 2004, we have ensured that Ubuntu is released on time, twice every&nbsp;year.</p>
-            </li>
-            <li class="three-col">
-                <img src="{{ ASSET_SERVER_URL }}0948d424-icon-ubuntu.svg" class="icon" alt="">
-                <p>Ubuntu is the leading OS in the cloud &mdash; OpenStack is built into Ubuntu Server and Ubuntu is the reference operating system for&nbsp;OpenStack.</p>
-            </li>
-            <li class="three-col last-col">
-                <img src="{{ ASSET_SERVER_URL }}a535811f-icon-cloud.svg" class="icon" alt="">
-                <p>With our partner network, we make Ubuntu available globally through retail channels and on most major public&nbsp;clouds.</p>
-            </li>
-        </ul>
-    </div>
+  <div class="inner-wrapper">
+    <h2>Canonical and Ubuntu</h2>
+    <ul class="connected-list">
+      <li class="three-col">
+        <img src="{{ ASSET_SERVER_URL }}6daed065-icon-canonical.svg" class="icon" alt="">
+        <p>Canonical defines Ubuntu&rsquo;s strategy and drives innovation with a team of over 400 dedicated designers, developers and project&nbsp;managers.</p>
+      </li>
+      <li class="three-col">
+        <img src="{{ ASSET_SERVER_URL }}b4a08b93-icon-calendar.svg" class="icon" alt="">
+        <p>Since 2004, we have ensured that Ubuntu is released on time, twice every&nbsp;year.</p>
+      </li>
+      <li class="three-col">
+        <img src="{{ ASSET_SERVER_URL }}0948d424-icon-ubuntu.svg" class="icon" alt="">
+        <p>Ubuntu is the leading OS in the cloud &mdash; OpenStack is built into Ubuntu Server and Ubuntu is the reference operating system for&nbsp;OpenStack.</p>
+      </li>
+      <li class="three-col last-col">
+        <img src="{{ ASSET_SERVER_URL }}a535811f-icon-cloud.svg" class="icon" alt="">
+        <p>With our partner network, we make Ubuntu available globally through retail channels and on most major public&nbsp;clouds.</p>
+      </li>
+    </ul>
+  </div>
 </div>
 
 <div class="row">
-	<div class="inner-wrapper">
+  <div class="inner-wrapper">
     <div class="twelve-col">
-        <h2>In the cloud&#58; driving enterprise agility</h2>
+      <h2>In the cloud&#58; driving enterprise agility</h2>
     </div>
     <div class="eight-col">
-        <p>Ubuntu is at the forefront of large cloud infrastructure deployments, thanks to Canonical&rsquo;s experience in building clouds for our customers and our involvement in the OpenStack project as a founding member. Ubuntu is also optimised and certified for the most popular public clouds &mdash; so wherever you choose to run your applications and services, you can always use&nbsp;Ubuntu.</p>
+      <p>Ubuntu is at the forefront of large cloud infrastructure deployments, thanks to Canonical&rsquo;s experience in building clouds for our customers and our involvement in the OpenStack project as a founding member. Ubuntu is also optimised and certified for the most popular public clouds &mdash; so wherever you choose to run your applications and services, you can always use&nbsp;Ubuntu.</p>
     </div>
-	</div>
+  </div>
 </div>
 
 <div class="juju-connected">
-	<div class="row">
-      <div class="inner-wrapper">
-         <img src="{{ ASSET_SERVER_URL }}b4b91175-juju-squid-apache-ceph-bundle.svg" alt="Juju charms connected" width="818" height="190">
-      </div>
-   </div>
+  <div class="row">
+    <div class="inner-wrapper">
+      <img src="{{ ASSET_SERVER_URL }}b4b91175-juju-squid-apache-ceph-bundle.svg" alt="Juju charms connected" width="818" height="190">
+    </div>
+  </div>
 </div>
 
 <div class="row">
-	<div class="inner-wrapper">
+  <div class="inner-wrapper">
     <div class="six-col">
-		<p>Canonical has also created several important tools to help customers build, manage and scale their clouds. For telcos and enterprises, <a href="https://www.ubuntu.com/management/landscape-features" class="external">Landscape</a> helps administrators deploy and manage Ubuntu clouds cost-effectively. And whether you are using your own cloud or someone else&rsquo;s, <a href="https://jujucharms.com" class="external">Juju</a> and <a href="http://maas.ubuntu.com/" class="external">MAAS</a> drastically reduce the time, cost and complexity of deploying and scaling in any cloud environment.</p>
+      <p>Canonical has also created several important tools to help customers build, manage and scale their clouds. For telcos and enterprises, <a href="https://www.ubuntu.com/management/landscape-features" class="external">Landscape</a> helps administrators deploy and manage Ubuntu clouds cost-effectively. And whether you are using your own cloud or someone else&rsquo;s, <a href="https://jujucharms.com" class="external">Juju</a> and <a href="http://maas.ubuntu.com/" class="external">MAAS</a> drastically reduce the time, cost and complexity of deploying and scaling in any cloud environment.</p>
     </div>
     <div class="prepend-two three-col last-col">
-        <blockquote class="pull-quote">
-        	<p><span>&ldquo;</span>Ubuntu remains the most popular operating system for&nbsp;OpenStack deployments&nbsp;<span>&rdquo;</span></p>
-			<p><cite>OpenStack User Survey, November 2013</cite></p>
-        </blockquote>
+      <blockquote class="pull-quote">
+        <p><span>&ldquo;</span>Ubuntu remains the most popular operating system for&nbsp;OpenStack deployments&nbsp;<span>&rdquo;</span></p>
+        <p><cite>OpenStack User Survey, November 2013</cite></p>
+      </blockquote>
     </div>
-	</div>
+  </div>
 </div>
 
 <div class="row strip-light">
-	<div class="inner-wrapper">
-	    <div class="twelve-col">
-	        <h2>On the client&#58; devops for IoT</h2>
-	    </div>
-	    <div class="eight-col">
-        <p>Ubuntu is the preferred development environment for embedded engineers and widely used in <a href="https://www.ubuntu.com/internet-of-things">IoT devices</a> across verticals: automotive, industrial, robotics, networking and digital signage. Canonical works with semiconductors to make certified Ubuntu images that brings the best performance out of their hardware.</p>
-        <p>With snaps, the universal Linux packaging system, and <a href="https://snapcraft.io">snapcraft.io</a> developers a tool to build and distribute their software across multiple devices to facilitate the deployment of applications in production environments.</p>
-        <p>Ubuntu Core is the all snap version of Ubuntu, built for security.</p>
-	    </div>
-	    <div class="twelve-col no-margin-bottom">
-	        <img src="{{ ASSET_SERVER_URL }}ca8a41c4-desktop-enterprise-hero.png" width="904" height="517" alt="Family of devices" />
-	    </div>
-	    <div class="eight-col">
-	        <p>Canonical works with most of the world&rsquo;s leading device and PC makers, to certify Ubuntu for use on a huge range of systems. As a result, Ubuntu is now available on computers for sale in over 3,000 retailers across Mexico, China and India.</p>
-	    </div>
-	</div>
+  <div class="inner-wrapper">
+    <div class="twelve-col">
+      <img src="{{ ASSET_SERVER_URL }}0a9abf66-desktop-enterprise-hero-trans.png" width="904" height="517" alt="Family of devices" />
+    </div>
+    <div class="six-col">
+      <h2>On the client: devops for IoT</h2>
+      <p>Ubuntu is the preferred development environment for embedded engineers. It is widely used in <a href="https://www.ubuntu.com/internet-of-things">IoT devices</a> across verticals: automotive, industrial, robotics, networking and digital signage. Canonical works with semiconductors to make certified Ubuntu images that brings the best performance out of their hardware.</p>
+      <p>With snaps, the universal Linux packaging system, and <a href="https://snapcraft.io">snapcraft.io</a> developers can easily build and distribute their software across multiple devices and environments. And Ubuntu Core is the all snap version of Ubuntu, built for security.</p>
+    </div>
+    <div class="six-col last-col">
+      <h2>On PCs: supported desktop</h2>
+      <p>The Ubuntu desktop is not only the environment of choice for millions of developers but also enterprises, government, educational institutions and anyone looking for a reliable, ease to use, versatile and secure operating system. Canonical offers support for enterprise desktop users with <a href="https://www.ubuntu.com/support">Ubuntu Advantage</a>.</p>
+      <p>Canonical works with most of the world&#39;s PC makers, to <a href="https://certification.ubuntu.com/">certify</a> Ubuntu for use on a huge range of devices. As a result, Ubuntu is now available on computers for sale in retailers and online across the globe.</p>
+    </div>
+  </div>
 </div>
 
 <div class="row row-contextual-footer">
-	<div class="inner-wrapper vertical-divider">
-		<div class="featured six-col">
-            <h3><a href="https://www.ubuntu.com" class="external">Explore ubuntu.com</a></h3>
-            <p>On ubuntu.com you&rsquo;ll find more information about the platform, our services, our management tools and our partner&nbsp;programs.</p>
-        </div>
-        <div class="three-col">
-            <h3><a href="/services">Learn more about services&nbsp;&rsaquo;</a></h3>
-            <p>Leading organisations all over the world turn to us for our management services and consultancy.</p>
-        </div>
-        <div class="three-col last-col">
-            <h3><a href="/partners">Learn more about partners&nbsp;&rsaquo;</a></h3>
-            <p>We help the biggest names in hardware, software and cloud to optimise, extend and deliver Ubuntu at scale.</p>
-        </div>
-	</div>
+  <div class="inner-wrapper vertical-divider">
+    <div class="featured six-col">
+      <h3><a href="https://www.ubuntu.com" class="external">Explore ubuntu.com</a></h3>
+      <p>On ubuntu.com you&rsquo;ll find more information about the platform, our services, our management tools and our partner&nbsp;programs.</p>
+    </div>
+    <div class="three-col">
+      <h3><a href="/services">Learn more about services&nbsp;&rsaquo;</a></h3>
+      <p>Leading organisations all over the world turn to us for our management services and consultancy.</p>
+    </div>
+    <div class="three-col last-col">
+      <h3><a href="/partners">Learn more about partners&nbsp;&rsaquo;</a></h3>
+      <p>We help the biggest names in hardware, software and cloud to optimise, extend and deliver Ubuntu at scale.</p>
+    </div>
+  </div>
 </div>
 {% endblock content %}

--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Canonical | Projects and technologies{% endblock %}
 {% block meta_description %}Canonical guides and contributes to the development of many open source projects in addition to Ubuntu. They include MIR, a next-generation display server, and Juju, a leading service orchestration tool.{% endblock %}
-{% block meta_keywords %}Canonical, Ubuntu, operating system, OS, open source, free, FOSS, technology, technologies, software, projects, Unity, user, interface, MIR, graphics, stack, Juju, service, orchestration, cloud, MAAS, metal as a service, server, provisioning, hyperscale,  Launchpad, collaboration, online, code, developer, tool, Upstart, init, daemon{% endblock %}
+{% block meta_keywords %}Canonical, Ubuntu, operating system, OS, open source, free, FOSS, technology, technologies, software, projects, user, interface, MIR, graphics, stack, Juju, service, orchestration, cloud, MAAS, metal as a service, server, provisioning, hyperscale,  Launchpad, collaboration, online, code, developer, tool, init, daemon{% endblock %}
 
 {% block extra_body_class %}projects-home{% endblock %}
 
@@ -60,17 +60,6 @@
                 </div>
             </li>
 
-            <li>
-                <a href="">
-                    <img src="{{ ASSET_SERVER_URL }}32c9eba3-image-project-upstart.png" alt="" class="large" />
-                    <img src="{{ ASSET_SERVER_URL }}6051979e-image-project-upstart-icon.png" alt="" class="small" />
-                    <h3>Upstart</h3>
-                </a>
-                <div>
-                    <p>Upstart is an event-based system that initialises services during boot, supervising them while the machine is running and stopping them during shutdown.</p>
-                    <p><a href="http://upstart.ubuntu.com" class="external">Learn more<span class="accessibility-aid"> about Upstart</span></a></p>
-                </div>
-            </li>
         </ul>
 
         <ul class="no-bullets three-col">
@@ -126,18 +115,6 @@
 
             <li>
                 <a href="">
-                    <img src="{{ ASSET_SERVER_URL }}cb908513-image-project-ubuntu-sdk.png" alt="" class="large" />
-                    <img src="{{ ASSET_SERVER_URL }}b7603fb6-image-project-ubuntu-sdk-icon.png" alt="" class="small" />
-                    <h3>Ubuntu App SDK</h3>
-                </a>
-                <div>
-                    <p>Ubuntu runs on all kinds of client devices, including tablets, phones and PCs. The Ubuntu App SDK comprises the developer tools and APIs needed to develop Ubuntu apps for any form factor.</p>
-                    <p><a href="http://developer.ubuntu.com/apps/" class="external">Learn more<span class="accessibility-aid"> about the App SDK</span></a></p>
-                </div>
-            </li>
-
-            <li>
-                <a href="">
                     <img src="{{ ASSET_SERVER_URL }}663faf72-image-project-launchpad.png" alt="" class="large" />
                     <img src="{{ ASSET_SERVER_URL }}859c6932-image-project-launchpad-icon.png" alt="" class="small" />
                     <h3>Launchpad</h3>
@@ -171,18 +148,6 @@
                 <div>
                     <p>In cloud environments, image-sprawl can quickly become a problem. Cloud-init is a system initialisation program that imports data from the provider (e.g. Amazon EC2 or Microsoft Azure) which can be used to configure new images with greater control.</p>
                     <p><a href="http://cloudinit.readthedocs.org/en/latest/" class="external">Learn more<span class="accessibility-aid"> about Cloud-init</span></a></p>
-                </div>
-            </li>
-
-            <li>
-                <a href="">
-                    <img src="{{ ASSET_SERVER_URL }}d7606e81-image-project-unity.png" alt="" class="large" />
-                    <img src="{{ ASSET_SERVER_URL }}6ac04b3b-image-project-unity-icon.png" alt="" class="small" />
-                    <h3>Unity</h3>
-                </a>
-                <div>
-                    <p>Unity is Ubuntu’s graphical user interface (GUI). Together with Mir, the new open source graphics stack, Unity makes Ubuntu easy to use  on a wide range of devices.</p>
-                    <p><a href="https://unity.ubuntu.com/" class="external">Learn more<span class="accessibility-aid"> about Unity</span></a></p>
                 </div>
             </li>
         </ul>


### PR DESCRIPTION
## Done

* updated the homepage text and images
* updated the projects page
* updated the partners' text and images
* updated the projects page
* updated the careers references

## QA

*see that the images have to mobile devices - ALL PAGES BELOW*

1. go to / and see that the copy matches the [copy doc](https://docs.google.com/document/d/1WcNN2RlQQrbLSP5ZgcIsAeQAHj5h_yDW6Yd5oBMmU3M/edit#)
2. go to /products and see the copy matches the [copy doc](https://docs.google.com/document/d/1-PY9w_BtCGS9CkSJqTKjOCkSzmgvROxfk-BcwitFEcE/edit)
3. go to /partners and see the copy matches the [copy doc](https://docs.google.com/document/d/1O7rMRIcRVINNsoiJ5fUQ4FPqUxGDKB3E6AaPZU2BAmc/edit#)
4. go to the vacancies pages and see they do not mention mobile

## Demo

[demo website](http://www.canonical.com-remove-mobile.demo.haus/)