### PR TITLE
Canonical logo should link to home

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -122,9 +122,9 @@ time {
 
 // Add a table wrapper to allow x-scrolling
 .table__wrapper {
+  margin: 2.5rem 0;
   overflow-x: auto;
   overflow-y: hidden;
-  margin: 2.5rem 0;
 }
 
 // p-card--footer needs margin-top

--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -45,7 +45,7 @@
       <div class="row">
       <div class="p-navigation__banner">
         <div class="p-navigation__logo">
-          <a class="p-navigation__link" href="#">
+          <a class="p-navigation__link" href="/">
             <img style="max-width: 100px;" src="{{ ASSET_SERVER_URL }}5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" />
           </a>
         </div>


### PR DESCRIPTION
## Done

Canonical logo should link to home

## QA

- Pull code
- Run `./run serve --watch`
- View http://0.0.0.0:8002/about
- Click logo in top left
- Browser should return to http://0.0.0.0:8002/

## Issue / Card

Fixes #189