### PR TITLE
Align the homepage lightbulb animation

### DIFF
--- a/static/sass/custom/_lightbulb-animation.scss
+++ b/static/sass/custom/_lightbulb-animation.scss
@@ -38,6 +38,10 @@
     margin-top: -20px;
     width: 538px;
 
+    * {
+      margin-top: 0;
+    }
+
     .background {
       background-size: 80%;
       background: url('https://assets.ubuntu.com/v1/1580f686-light-beams.png') no-repeat scroll center center;


### PR DESCRIPTION
## Done
Removed margin-top from all elements of the animation.

## QA
- Pull down this code
- Run `./run`
- Go to http://0.0.0.0:8002/
- Check that the light bulb is aligned correctly

## Issue / Card
Fixes https://github.com/canonical-websites/www.canonical.com/issues/182
Fixes https://github.com/ubuntudesign/vanilla-squad/issues/81

