### PR TITLE
Fix the wrapping external links in the contextual footers

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -413,11 +413,11 @@
         </div>
       </div>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-4 p-divider__block">
       <h3><a href="/partners/contact-us">Contact us about partnerships&nbsp;&rsaquo;</a></h3>
       <p>Interested in becoming a partner? Talk to us today for more information about our services and certification.</p>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-4 p-divider__block">
       <p>Media or analysts seeking press information or interviews should email <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
     </div>
   </div>

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -166,19 +166,19 @@
     <div class="col-6 p-divider__block">
       <div class="u-equal-height">
         <div class="col-4">
-        <h3><a href="/partners/contact-us">Contact us about becoming a partner&nbsp;&rsaquo;</a></h3>
-        <p>Interested in becoming a partner? Talk to us today for more information about our services and certification.</p>
-      </div>
+          <h3><a href="/partners/contact-us">Contact us about becoming a partner&nbsp;&rsaquo;</a></h3>
+          <p>Interested in becoming a partner? Talk to us today for more information about our services and certification.</p>
+        </div>
         <div class="col-2 u-vertically-center u-hide u-visible--large">
-        <img src="{{ ASSET_SERVER_URL }}fe022948-image-footer-certification.svg" alt="">
-      </div>
+          <img src="{{ ASSET_SERVER_URL }}fe022948-image-footer-certification.svg" alt="">
+        </div>
       </div>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-4 p-divider__block">
       <h3><a href="http://partners.ubuntu.com" class="p-link--external">Learn more about partners</a></h3>
       <p>On our <a href="http://partners.ubuntu.com" class="p-link--external">partners website</a>, you'll find more information about hardware, software, cloud and reseller partners.</p>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-4 p-divider__block">
       <h3><a href="/services/contact-us">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></h3>
       <p>Interested in Ubuntu Advantage? Talk to us about our management services and consultancy.</p>
     </div>

--- a/templates/services/index.html
+++ b/templates/services/index.html
@@ -123,12 +123,12 @@
       </div>
       </div>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-4 p-divider__block">
       <h3><a class="p-link--external" href="https://insights.ubuntu.com/2014/03/25/an-ubuntu-pc-for-everyone-in-penn-manor-school-district-pennsylvania-usa/">View case study&nbsp;</a></h3>
       <p>An Ubuntu PC for everyone in Penn Manor School District, Pennsylvania, USA.</p>
     </div>
-    <div class="col-3 p-divider__block">
-      <h3><a href="/services/contact-us">Contact us today &rsaquo;</a></h3>
+    <div class="col-4 p-divider__block">
+      <h3><a href="/services/contact-us">Contact us today&nbsp;&rsaquo;</a></h3>
       <p>Interested in Ubuntu Advantage? Talk to us today for more information.</p>
     </div>
   </div>


### PR DESCRIPTION
## Done
Fix the wrapping external links in the contextual footers. I believe the changed layout looks nicer too.

## QA
- Pull down code
- Run `./run`
- Go to http://0.0.0.0:8002/about
- Go to http://0.0.0.0:8002/partners
- Go to http://0.0.0.0:8002/services
- Scroll to the footers and check the external icons don't wrap

## Issue / Card
Fixes https://github.com/canonical-websites/www.canonical.com/issues/184
Fixes https://github.com/ubuntudesign/vanilla-squad/issues/82

