### PR TITLE
Update the cookie policy dependency to v1.0.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
   ],
   "dependencies": {
     "canonical-global-nav": "^0.2.0",
-    "canonical-cookie-policy": "^1.0.1"
+    "canonical-cookie-policy": "^1.0.2"
   }
 }


### PR DESCRIPTION
## Done
Updated the cookie policy dep to the latest version. Solving the issue that cookie policy is not closeable on iPhones.

## QA
- Pull down this branch
- Run `./run clean`
- Run `./run`
- Check that the output contains `bower canonical-cookie-policy#^1.0.2`
- Go to http://0.0.0.0:8002/
- Check the cookie policy works (you may need to delete the `_cookie_accepted` cookie using your browers inspector

