### PR TITLE
Switched locations for cloud and ubuntu icons on products page

### DIFF
--- a/templates/products/index.html
+++ b/templates/products/index.html
@@ -52,13 +52,13 @@
       </li>
       <li class="col-3">
         <p>
-          <img width="48" src="{{ ASSET_SERVER_URL }}0948d424-icon-ubuntu.svg" alt="">
+          <img width="48" src="{{ ASSET_SERVER_URL }}a535811f-icon-cloud.svg" alt="">
         </p>
         <p>Ubuntu is the leading OS in the cloud &mdash; OpenStack is built into Ubuntu Server and Ubuntu is the reference operating system for&nbsp;OpenStack.</p>
       </li>
       <li class="col-3">
         <p>
-          <img width="48" src="{{ ASSET_SERVER_URL }}a535811f-icon-cloud.svg" alt="">
+          <img width="48" src="{{ ASSET_SERVER_URL }}0948d424-icon-ubuntu.svg" alt="">
         </p>
         <p>With our partner network, we make Ubuntu available globally through retail channels and on most major public&nbsp;clouds.</p>
       </li>


### PR DESCRIPTION
## Done

- Corrected the location of the cloud and ubuntu icons on the 'Canonical and Ubuntu' banner

## QA

- Check that the cloud icon is in the third column and ubuntu icon is in the fourth

## Issue / Card

Fixes #212 
