### PR TITLE
Removed suffix-1 from two columns of text on /products

### DIFF
--- a/templates/products/index.html
+++ b/templates/products/index.html
@@ -96,7 +96,7 @@
 
 <section class="p-strip is-deep">
   <div class="row">
-    <div class="col-12">
+    <div class="col-12 u-align--center">
       <img src="{{ ASSET_SERVER_URL }}0a9abf66-desktop-enterprise-hero-trans.png" width="904" height="517" alt="Family of devices" />
     </div>
   </div>

--- a/templates/products/index.html
+++ b/templates/products/index.html
@@ -106,7 +106,7 @@
       <p>Ubuntu is the preferred development environment for embedded engineers. It is widely used in <a class="p-link--external" href="https://www.ubuntu.com/internet-of-things">IoT devices</a> across verticals: automotive, industrial, robotics, networking and digital signage. Canonical works with semiconductors to make certified Ubuntu images that brings the best performance out of their hardware.</p>
       <p>With snaps, the universal Linux packaging system, and <a class="p-link--external" href="https://snapcraft.io">snapcraft.io</a> developers can easily build and distribute their software across multiple devices and environments. And Ubuntu Core is the all snap version of Ubuntu, built for security.</p>
     </div>
-    <div class="col-6 prefix-1">
+    <div class="col-6">
       <h2>On PCs: supported desktop</h2>
       <p>The Ubuntu desktop is not only the environment of choice for millions of developers but also enterprises, government, educational institutions and anyone looking for a reliable, ease to use, versatile and secure operating system. Canonical offers support for enterprise desktop users with <a href="https://www.ubuntu.com/support" class="p-link--external">Ubuntu Advantage</a>.</p>
       <p>Canonical works with most of the world&#39;s PC makers, to <a class="p-link--external" href="https://certification.ubuntu.com/">certify</a> Ubuntu for use on a huge range of devices. As a result, Ubuntu is now available on computers for sale in retailers and online across the globe.</p>


### PR DESCRIPTION
## Done

* Removed suffix-1 from two columns of text on /products in the ‘On the client: devops for IoT’ section as it looked unbalanced

## QA

- download the branch
- `./run` the site
- look at [product page](http://0.0.0.0:8002/products)

## Screenshots

### before
![image](https://user-images.githubusercontent.com/441217/33230476-ed7981f8-d1db-11e7-87d4-a3069e2894d3.png)

### after
![image](https://user-images.githubusercontent.com/441217/33230495-54d5af48-d1dc-11e7-8717-b646d4719b30.png)


