### PR TITLE
Zoomed out google map on /about page

### DIFF
--- a/templates/about/map.html
+++ b/templates/about/map.html
@@ -29,7 +29,7 @@
     function initialize() {
       var starting = new google.maps.LatLng(40, 0);
       var mapOptions = {
-        zoom: 3,
+        zoom: 2,
         scrollwheel: false,
         center: starting
       }


### PR DESCRIPTION
## Done

* Zoomed out google map on /about page to show all our offices better

## QA

1. get this branch
2. `./run` the site
3. look at [about page](http://0.0.0.0:8002/about)

## Issue / Card

Fixes #217

## Screenshots

![image](https://user-images.githubusercontent.com/441217/33230616-a65dbf3e-d1de-11e7-9a61-d3f1e551e87a.png)
