### PR TITLE
Removed the Boston office from the /about page map

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -272,18 +272,6 @@
 
     <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content p-card address">
       <div>
-        <h3 class="title">Boston, United States</h3>
-        <p>Canonical USA Inc.<br />
-          <span itemprop="streetAddress">Suite 212 Lexington Corporate Center</span><br />
-          <span itemprop="streetAddress">10 Maguire Road</span><br />
-          <span itemprop="addressRegion">Lexington</span>, <span itemprop="postalCode">MA 02421</span><br />
-          <span itemprop="addressCountry">United States of America</span><br />
-          <a href="https://maps.google.co.uk/maps?q=10+Maguire+Rd,+Lexington,+MA,+USA&amp;hl=en&amp;sll=42.510443,-71.260566&amp;sspn=1.186442,2.554321&amp;hnear=10+Maguire+Rd,+Lexington,+Massachusetts+02421,+United+States&amp;t=m&amp;z=16">View map &rsaquo;</a></p>
-      </div>
-    </div>
-
-    <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content p-card address">
-      <div>
         <h3 class="title">Shanghai, China</h3>
         <p itemprop="streetAddress">Room 1246, 12F<br />
           <span itemprop="streetAddress">No. 331 North Caoxi Road</span><br />

--- a/templates/about/map.html
+++ b/templates/about/map.html
@@ -48,14 +48,6 @@
         '2301 W Anderson Ln <br />' +
         'Austin, TX 78757<br />USA</p>'
       });
-      var bostonInfo = new google.maps.InfoWindow({
-        content: '<h2>Boston, United States</h2>' +
-        '<p>Canonical USA Inc. <br />' +
-        'Suite 212 Lexington Corporate Center <br />' +
-        '10 Maguire Road <br />' +
-        'Lexington, MA 02421 <br />' +
-        'United States of America</p>'
-      });
       var shanghaiInfo = new google.maps.InfoWindow({
         content: '<h2>Shanghai, China</h2>' +
         '<p>Room 1246, 12F <br />' +
@@ -108,11 +100,6 @@
               map: map,
               title: "Austin, United States"
             });
-            var boston = new google.maps.Marker({
-              position: new google.maps.LatLng(42.428691, -71.228023),
-              map: map,
-              title: "Boston, United States"
-            });
             var shanghai = new google.maps.Marker({
               position: new google.maps.LatLng(31.1747322, 121.4351965),
               map: map,
@@ -141,7 +128,6 @@
 
             google.maps.event.addListener(london, 'click', function() {
               austinInfo.close();
-              bostonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
               taipeiInfo.close();
@@ -149,18 +135,7 @@
               japanInfo.close();
               londonInfo.open(map, london);
             });
-            google.maps.event.addListener(boston, 'click', function() {
-              austinInfo.close();
-              londonInfo.close();
-              shanghaiInfo.close();
-              beijingInfo.close();
-              taipeiInfo.close();
-              iomInfo.close();
-              japanInfo.close();
-              bostonInfo.open(map, boston);
-            });
             google.maps.event.addListener(austin, 'click', function() {
-              bostonInfo.close();
               londonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
@@ -171,7 +146,6 @@
             });
             google.maps.event.addListener(shanghai, 'click', function() {
               austinInfo.close();
-              bostonInfo.close();
               londonInfo.close();
               beijingInfo.close();
               taipeiInfo.close();
@@ -181,7 +155,6 @@
             });
             google.maps.event.addListener(beijing, 'click', function() {
               austinInfo.close();
-              bostonInfo.close();
               shanghaiInfo.close();
               londonInfo.close();
               taipeiInfo.close();
@@ -191,7 +164,6 @@
             });
             google.maps.event.addListener(taipei, 'click', function() {
               austinInfo.close();
-              bostonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
               londonInfo.close();
@@ -201,7 +173,6 @@
             });
             google.maps.event.addListener(iom, 'click', function() {
               austinInfo.close();
-              bostonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
               taipeiInfo.close();
@@ -211,7 +182,6 @@
             });
             google.maps.event.addListener(japan, 'click', function() {
               austinInfo.close();
-              bostonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
               taipeiInfo.close();


### PR DESCRIPTION
## Done

* Removed the Boston office from the /about page map

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [about page](http://0.0.0.0:8002/about) and see there is no Boston office

## Issue / Card

Fixes #230