### PR TITLE
Remove Anand from executives in the about page

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -105,7 +105,6 @@
       <div class="tabbed-menu">
         <ul class="p-list">
           <li><a class="is-active" href="#mark-shuttleworth">Mark Shuttleworth</a></li>
-          <li><a href="#anand-krishnan">Anand Krishnan</a></li>
           <li><a href="#mike-bell">Mike Bell</a></li>
           <li><a href="#neil-french">Neil French</a></li>
           <li><a href="#seb-butter">Seb Butter</a></li>
@@ -130,26 +129,6 @@
         <div class="col-4">
           <blockquote class="p-pull-quote">
             <p>Contributing to Ubuntu is a profession for some and a passion for others. Either way, it’s changing the world.</p>
-          </blockquote>
-        </div>
-      </div>
-    </div>
-    <div class="col-9 tabbed-content p-card u-hide" id="anand-krishnan">
-      <div class="row">
-        <div class="col-5">
-          <img class="portrait" itemprop="image" src="{{ ASSET_SERVER_URL }}74c207a8-Anand+Krishnan-canonical.png" alt="Anand Krishnan">
-          <ul class="p-list u-no-margin--top">
-            <li class="p-heading--four" itemprop="name">Anand Krishnan</li>
-            <li class="u-no-margin--top" itemprop="jobTitle">EVP, Cloud &amp; General Manager</li>
-          </ul>
-          <p class="u-clear">Anand heads up Canonical's cloud division and is responsible for all its product, marketing, sales, business development and support. In addition, he is also General Manager across the whole Canonical business. Before joining Canonical, Anand held several leadership positions at Microsoft Corp and helped launch and build several successful businesses both at Microsoft and in the startup world prior to that.</p>
-          <ul class="p-list">
-            <li><a class="p-link--external" href="https://www.linkedin.com/in/akris">View Anand on LinkedIn</a></li>
-          </ul>
-        </div>
-        <div class="col-4">
-          <blockquote class="p-pull-quote">
-            <p>Helping customers build and use the cloud that best fits them — our mission is to make that a reality for any customer of any size.</p>
           </blockquote>
         </div>
       </div>


### PR DESCRIPTION
## Done
Removed Anand from the exec section of the about page

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/about](http://0.0.0.0:8002/about)
4. Scroll to "Our management team" section
5. Check Anand is not there.

## Issue / Card
Fixes https://github.com/canonical-websites/www.canonical.com/issues/233#issuecomment-357247830

## Screenshots
![screenshot-2018-1-14 canonical about the company](https://user-images.githubusercontent.com/1413534/34914339-bea5b168-f908-11e7-86be-5792143c0922.png)
