### PR TITLE
Add contact link to footer

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -115,3 +115,7 @@ time {
   }
 }
 
+// Override max-width on `p` tags
+.u-no-max-width {
+  max-width: 100%;
+}

--- a/templates/_base/footer.html
+++ b/templates/_base/footer.html
@@ -2,11 +2,11 @@
 <footer class="p-footer" role="contentinfo">
   <div class="row">
     <ul class="p-inline-list">
-      <li class="u-hide--small p-inline-list__item">
-        <a class="p-button--neutral is-compact" href="/services/contact-us"><small>Contact us</small></a>
+      <li class="p-inline-list__item">
+        <a class="p-button--neutral is-compact" href="https://www.ubuntu.com/contact-us"><small>Contact us</small></a>
       </li>
     </ul>
-    <p>&copy; Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+    <p class="u-no-max-width">&copy; Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
     <nav class="p-footer__nav" role="navigation">
       <ul class="p-footer__links">
         <li class="p-footer__item">

--- a/templates/_base/footer.html
+++ b/templates/_base/footer.html
@@ -1,6 +1,11 @@
 {% block footer %}
 <footer class="p-footer" role="contentinfo">
   <div class="row">
+    <ul class="p-inline-list">
+      <li class="u-hide--small p-inline-list__item">
+        <a class="p-button--neutral is-compact" href="/services/contact-us"><small>Contact us</small></a>
+      </li>
+    </ul>
     <p>&copy; Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
     <nav class="p-footer__nav" role="navigation">
       <ul class="p-footer__links">


### PR DESCRIPTION
## Done

- Add contact link to footer

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. Look at the footer on any page and make sure the contact us link/button is there


## Issue / Card

[Fixes #245](https://app.zenhub.com/workspace/o/canonical-websites/www.canonical.com/issues/245)

## Screenshots

![canonical the company behind ubuntu](https://user-images.githubusercontent.com/501889/37531698-ced7beb2-2934-11e8-8068-0eaf46d9d4c5.jpg)
