### PR TITLE
Fix typos on services page

### DIFF
--- a/templates/services/index.html
+++ b/templates/services/index.html
@@ -101,7 +101,7 @@
           <span class="p-list-step__bullet">3</span>
           Train
         </h3>
-          <p>Training is a vital element of a successful the handover of the new system.  The transfer of detailed knowledge to your team on how to manage your deployment is critical. For clouds, we also cover scaling and moving workloads.</p>
+          <p>Training is a vital element of a successful handover of the new system.  The transfer of detailed knowledge to your team on how to manage your deployment is critical. For clouds, we also cover scaling and moving workloads.</p>
         </li>
 
         <li class="p-list-step__item">
@@ -109,7 +109,7 @@
           <span class="p-list-step__bullet">4</span>
           Manage
         </h3>
-          <p>As your business evolves, we collaborate closely with your team to monitor and optimise your deployment on an ongoing basis, taking advantage of any opportunities to enhance effectiveness and efficiency.www</p>
+          <p>As your business evolves, we collaborate closely with your team to monitor and optimise your deployment on an ongoing basis, taking advantage of any opportunities to enhance effectiveness and efficiency</p>
         </li>
       </ol>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,9 +998,9 @@ glob@~3.1.21:
     inherits "1"
     minimatch "~0.2.11"
 
-global-nav@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-0.1.3.tgz#98b997bbd701ab00bfc53e37c17469d80c04b519"
+global-nav@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-0.2.2.tgz#fc72aa66739e1a161fbaed4c71bb56d077371314"
 
 globals@^9.2.0:
   version "9.18.0"


### PR DESCRIPTION
## Done

Fix typos on services page

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: <http://0.0.0.0:8002/services>
4. Check that typos referenced in issue description have been removed


## Issue / Card

Fixes #241 

