### PR TITLE
Update copyright notice in footer

### DIFF
--- a/templates/_base/footer.html
+++ b/templates/_base/footer.html
@@ -6,7 +6,7 @@
         <a class="p-button--neutral is-compact" href="https://www.ubuntu.com/contact-us"><small>Contact us</small></a>
       </li>
     </ul>
-    <p class="u-no-max-width">&copy; Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+    <p class="u-no-max-width">&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
     <nav class="p-footer__nav" role="navigation">
       <ul class="p-footer__links">
         <li class="p-footer__item">


### PR DESCRIPTION
## Done

Update copyright notice in footer

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. Make sure the footer copyright notice is: " © 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd."


## Issue / Card

[Fixes #235](https://app.zenhub.com/workspace/o/canonical-websites/www.canonical.com/issues/235)

