### PR TITLE
www.canonical.com upgrade vanilla-framework to v1.7.0-alpha-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postcss": "^6.0.8",
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",
-    "vanilla-framework": "1.6.3"
+    "vanilla-framework": "1.7.0-alpha-1"
   },
   "dependencies": {
     "global-nav": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,9 +2812,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.3.tgz#92271d5dc765d7563659684ed4797e3919160f01"
+vanilla-framework@1.7.0-alpha-1:
+  version "1.7.0-alpha-1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.0-alpha-1.tgz#cbf6ce65c97a3cece65a0bb6274904cf81918b94"
 
 vendors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Done
Updated vanilla-framework to 1.7.0-alpha-1 and changed the logo link to be relative.

## QA
Check out the demo and see if there are issues.