### PR TITLE
Pin Gunicorn to 19.7.0 to avoid umask error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ requests==2.10.0
 requests-cache==0.4.12
 python-dateutil==2.7.0
 talisker==0.9.6
+# Gunicorn 19.7.1 has a bug that errors with "--umask=0". Update when possible.
+gunicorn==19.7.0


### PR DESCRIPTION
Gunicorn 19.7.1 creates an error in our deployment from a bug when using
the `--umask=0` flag. Locking to the previous verison avoids this bug.
( Reference https://github.com/benoitc/gunicorn/issues/1622 )


## QA

- `./run build` - Just to update requirements
- `./run exec -p 8002 "gunicorn webapp.wsgi --umask=0"`

Server should start up ~but the port isn't forwarded so the site isn't visible~
