### PR TITLE
Bespoke styling fixes for Vanilla 1.7.0-beta

### DIFF
--- a/static/sass/_pattern_link.scss
+++ b/static/sass/_pattern_link.scss
@@ -1,19 +1,30 @@
 @mixin canonical-p-link {
+  %external-link-heading {
+    background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') no-repeat;
+    background-size: .85em;
+    padding-left: 1em;
+
+    &::after {
+      display: none;
+    }
+  }
+
   h1,
   h2,
   h3,
-  h4,
-  h5,
-  h6 {
+  h4 {
     &.p-link--external {
-      background: url('#{$assets-path}e1bba201-external-link-cool-grey.svg') left .2em no-repeat;
-      background-size: .85em;
-      color: $color-dark;
-      padding-left: 1em;
+      @extend %external-link-heading;
+      background-position: left;
+    }
+  }
 
-      &::after {
-        display: none;
-      }
+  h5,
+  h6,
+  .p-heading--insights__title {
+    &.p-link--external {
+      @extend %external-link-heading;
+      background-position: left .75em;
     }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -59,3 +59,8 @@ time {
 .u-no-max-width {
   max-width: 100%;
 }
+
+// Custom split list over 2 columns
+.p-list-step.is-split {
+  column-gap: 5rem;
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -48,71 +48,11 @@ time {
   }
 }
 
-// Util for clearing
-.u-clear {
-  clear: both;
-}
-
-// Custom margin-top spacing
-.further-info {
-
-  .p-list--divided {
-    margin-top: $sp-medium;
-  }
-}
-
-
-// increase height of /products hero on medium screens
-.products-hero {
-
-  @media (min-width: $breakpoint-medium + 1) {
-    min-height: 450px;
-
-    .content-wrap {
-      margin-top: 3rem;
-    }
-  }
-
-  @media (min-width: $breakpoint-large) {
-    min-height: 500px;
-
-    .content-wrap {
-      margin-top: 2rem;
-    }
-  }
-}
-
-// Add extra margin-bottom to 'Join us' list grid
-.join-us {
-
-  @media (min-width: $sp-medium) {
-
-    .p-list li:nth-child(odd) {
-      margin-bottom: $sp-x-large;
-    }
-  }
-}
-
-
 // Add a table wrapper to allow x-scrolling
 .table__wrapper {
   margin: 2.5rem 0;
   overflow-x: auto;
   overflow-y: hidden;
-}
-
-// XXX Ant: 04.12.17 This can be removed when this is fixed
-// https://github.com/vanilla-framework/vanilla-framework/issues/1478
-.u-align--center {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  p {
-    max-width: none;
-  }
 }
 
 // Override max-width on `p` tags

--- a/templates/_base/base.html
+++ b/templates/_base/base.html
@@ -46,7 +46,7 @@
       <div class="p-navigation__banner">
         <div class="p-navigation__logo">
           <a class="p-navigation__link" href="/">
-            <img style="max-width: 100px;" src="{{ ASSET_SERVER_URL }}5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" />
+            <img class="p-navigation__image" src="{{ ASSET_SERVER_URL }}5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical logo" width="100" />
           </a>
         </div>
         <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -119,7 +119,7 @@
             <li class="name p-heading--four" itemprop="name">Mark Shuttleworth</li>
             <li class="u-no-margin--top" itemprop="jobTitle">Founder &amp; CEO</li>
           </ul>
-          <p class="u-clear">Mark founded security specialist Thawte in 1996, and became the first South African in space when he flew to the ISS in 2002 on Soyuz TM-34. He founded Ubuntu and Canonical in 2004, combining responsibility for strategy and user experience at Canonical with roles on the Ubuntu Technical Board and Community Council.</p>
+          <p>Mark founded security specialist Thawte in 1996, and became the first South African in space when he flew to the ISS in 2002 on Soyuz TM-34. He founded Ubuntu and Canonical in 2004, combining responsibility for strategy and user experience at Canonical with roles on the Ubuntu Technical Board and Community Council.</p>
           <ul class="p-list">
             <li><a class="p-link--external" href="https://markshuttleworth.com/">Read Mark's blog</a></li>
             <li><a class="p-link--external" href="https://plus.google.com/103552930976410494054/posts">Follow Mark on Google+</a></li>
@@ -140,7 +140,7 @@
             <li class="name p-heading--four" itemprop="name">Neil French</li>
             <li class="u-no-margin--top" itemprop="jobTitle">VP, Operations</li>
           </ul>
-          <p class="u-clear">Neil is responsible for all of Canonical’s internal operations. Before joining Canonical, he was the Director of Commercial Operations at Thomsons Online Benefits, the leading Software-as-a-Service provider for global employee benefits administration, and before that held business and product leadership roles at Epson, 3Com and Hewlett-Packard.</p>
+          <p>Neil is responsible for all of Canonical’s internal operations. Before joining Canonical, he was the Director of Commercial Operations at Thomsons Online Benefits, the leading Software-as-a-Service provider for global employee benefits administration, and before that held business and product leadership roles at Epson, 3Com and Hewlett-Packard.</p>
           <ul class="p-list">
             <li><a class="p-link--external" href="https://www.linkedin.com/in/neilfrench">View Neil on LinkedIn</a></li>
           </ul>
@@ -160,7 +160,7 @@
             <li class="name p-heading--four" itemprop="name">Seb Butter</li>
             <li class="u-no-margin--top" itemprop="jobTitle">Finance Director</li>
           </ul>
-          <p class="u-clear">Seb is responsible for Canonical’s finance function. Before joining Canonical, he held Group Financial Controller positions at both Alternative Networks and Centaur Media. Seb also spent 10 years at Deloitte rising to the position of Senior Manager.</p>
+          <p>Seb is responsible for Canonical’s finance function. Before joining Canonical, he held Group Financial Controller positions at both Alternative Networks and Centaur Media. Seb also spent 10 years at Deloitte rising to the position of Senior Manager.</p>
           <ul class="p-list">
             <li><a class="p-link--external" href="https://www.linkedin.com/in/seb-butter-46bb9b38/">View Seb on LinkedIn</a></li>
           </ul>
@@ -180,7 +180,7 @@
             <li class="p-heading--four" itemprop="name">Jane Silber</li>
             <li class="u-no-margin--top" itemprop="jobTitle">Board Member</li>
           </ul>
-          <p class="u-clear">Jane is a board member of Canonical after holding leadership roles since 2004, including CEO. Prior to joining Canonical, Jane held various positions in business development, operations and software management at companies including Interactive Television Company and General Dynamics C4 Systems.</p>
+          <p>Jane is a board member of Canonical after holding leadership roles since 2004, including CEO. Prior to joining Canonical, Jane held various positions in business development, operations and software management at companies including Interactive Television Company and General Dynamics C4 Systems.</p>
           <ul class="p-list">
             <li><a class="p-link--external" href="https://uk.linkedin.com/in/jane-silber-934901">View Jane on LinkedIn</a></li>
           </ul>
@@ -325,7 +325,7 @@
   </div>
 </section>
 
-<section class="p-strip-light is-deep is-bordered further-info">
+<section class="p-strip-light is-deep is-bordered">
     <div class="row">
       <div class="col-12">
         <h2>Further information</h2>

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -35,9 +35,9 @@
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered u-align--center">
+<section class="p-strip is-deep is-bordered">
   <div class="row">
-      <h2 class="p-muted-heading">A selection of our cloud partners</h2>
+      <h2 class="p-muted-heading u-align-text--center">A selection of our cloud partners</h2>
       {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Cloud/server&featured=true" limit=10 as cloud_partners %}
       {% if cloud_partners is False %}
         <p>Feed failed to load. If you have time, please <a href="https://github.com/canonical-websites/www.canonical.com/issues/new">file an issue</a>.</p>
@@ -50,7 +50,7 @@
         {% endfor %}
       </ul>
       {% endif %}
-      <p><a href="http://partners.ubuntu.com/find-a-partner?technology=cloud/server" class="p-link--external">Browse all cloud partners</a></p>
+      <p class="u-align-text--center"><a href="http://partners.ubuntu.com/find-a-partner?technology=cloud/server" class="p-link--external">Browse all cloud partners</a></p>
   </div>
 </section>
 
@@ -84,10 +84,10 @@
 </section>
 
 
-<section class="p-strip u-align--center">
+<section class="p-strip">
   <div class="row">
     <div class="panel panel--alt col-12">
-      <h2 class="p-muted-heading">A selection of our IoT device and PC partners</h2>
+      <h2 class="p-muted-heading u-align-text--center">A selection of our IoT device and PC partners</h2>
       {% get_json_feed "http://partners.ubuntu.com/partners.json?programme__name=Technical Partner Programme" limit=10 as client_partners %}
       {% if client_partners is False %}
         <p>Feed failed to load. If you have time, please <a href="https://github.com/canonical-websites/www.canonical.com/issues/new">file an issue</a>.</p>
@@ -100,7 +100,7 @@
         {% endfor %}
       </ul>
       {% endif %}
-      <p><a href="http://partners.ubuntu.com/find-a-partner?technology=personal-computing/devices" class="p-link--external">Browse all IoT device and PC partners</a></p>
+      <p class="u-align-text--center"><a href="http://partners.ubuntu.com/find-a-partner?technology=personal-computing/devices" class="p-link--external">Browse all IoT device and PC partners</a></p>
     </div>
   </div>
 </section>

--- a/templates/services/index.html
+++ b/templates/services/index.html
@@ -26,7 +26,7 @@
 
 <section class="p-strip">
   <div class="row">
-    <h2 class="p-muted-heading u-align--center">A selection of customers using our services</h2>
+    <h2 class="p-muted-heading u-align-text--center">A selection of customers using our services</h2>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
         <img src="{{ ASSET_SERVER_URL }}e7c7aa47-logo-wikimedia-foundation.png" alt="Wikimedia logo" />

--- a/templates/services/index.html
+++ b/templates/services/index.html
@@ -75,44 +75,36 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-6">
-      <ol class="p-list-step">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-          <span class="p-list-step__bullet">1</span>
-          Plan and install
-        </h3>
-          <p>We examine your business problem and operational requirements before building and installing a proposed solution. Performance is monitored and a full report accompanies the resulting deployment recommendations.</p>
-        </li>
-
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-          <span class="p-list-step__bullet">2</span>
-          Deploy
-        </h3>
-          <p>The system is now rolled out, configured for optimum security and performance. At this stage, your Ubuntu Advantage subscription begins, making management and support more cost-effective from this point.</p>
-        </li>
-      </ol>
-    </div>
-    <div class="col-6">
-      <ol class="p-list-step">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-          <span class="p-list-step__bullet">3</span>
-          Train
-        </h3>
-          <p>Training is a vital element of a successful handover of the new system.  The transfer of detailed knowledge to your team on how to manage your deployment is critical. For clouds, we also cover scaling and moving workloads.</p>
-        </li>
-
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-          <span class="p-list-step__bullet">4</span>
-          Manage
-        </h3>
-          <p>As your business evolves, we collaborate closely with your team to monitor and optimise your deployment on an ongoing basis, taking advantage of any opportunities to enhance effectiveness and efficiency</p>
-        </li>
-      </ol>
-    </div>
+    <ol class="p-list-step is-split">
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+        <span class="p-list-step__bullet">1</span>
+        Plan and install
+      </h3>
+        <p>We examine your business problem and operational requirements before building and installing a proposed solution. Performance is monitored and a full report accompanies the resulting deployment recommendations.</p>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+        <span class="p-list-step__bullet">2</span>
+        Deploy
+      </h3>
+        <p>The system is now rolled out, configured for optimum security and performance. At this stage, your Ubuntu Advantage subscription begins, making management and support more cost-effective from this point.</p>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+        <span class="p-list-step__bullet">3</span>
+        Train
+      </h3>
+        <p>Training is a vital element of a successful handover of the new system.  The transfer of detailed knowledge to your team on how to manage your deployment is critical. For clouds, we also cover scaling and moving workloads.</p>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+        <span class="p-list-step__bullet">4</span>
+        Manage
+      </h3>
+        <p>As your business evolves, we collaborate closely with your team to monitor and optimise your deployment on an ongoing basis, taking advantage of any opportunities to enhance effectiveness and efficiency</p>
+      </li>
+    </ol>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Removed bespoke css that has been solved with the new spacing
- Fixed navigation logo alignment
- Fixed heading external link vertical alignment
- Fixed center-aligned muted headings
- Fixed numbering on the stepped list in /services

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Check that the logo is center-aligned in the nav, not top-aligned
- Go to /careers/all-vacancies and check that the external link icons are aligned properly in the section headers
- Go to /services and check that the muted headings are centered
- Also check that the stepped list is numbered properly

## Issue / Card

Fixes vanilla-framework/vanilla-framework#1726
Fixes vanilla-framework/vanilla-framework#1728
Fixes vanilla-framework/vanilla-framework#1729
Fixes vanilla-framework/vanilla-framework#1731
