### PR TITLE
Update the projects/directory page

### DIFF
--- a/templates/projects/directory.html
+++ b/templates/projects/directory.html
@@ -31,13 +31,19 @@
             </tr>
 
             <tr>
+              <th scope='row'>Candid authentication service</th>
+              <td>candid</td>
+              <td>Uros Jovanovic (uros.jovanovic&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
+            </tr>
+
+            <tr>
               <th scope='row'>Canonical-copyright opensource project</th>
               <td>pam-xdg-support</td>
               <td>Steve Langasek (steve.langasek&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
             </tr>
 
             <tr>
-              <th scope='row'>Click Packages (DEPRECATED)</th>
+              <th scope='row'>Click Packages (DEPRICIATED)</th>
               <td>click-update-manager,<br /> unity-scope-click,
                 <br /> packagekit-plugin-click,
                 <br /> click-apparmor,
@@ -66,7 +72,7 @@
             </tr>
 
             <tr>
-              <th scope='row'>Freedesktop.org- compliant notification service (DEPRECATED)</th>
+              <th scope='row'>Freedesktop.org- compliant notification service (DEPRICIATED)</th>
               <td>notify-osd</td>
               <td>Bret Barker (bret.barker&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
             </tr>
@@ -78,7 +84,7 @@
             </tr>
 
             <tr>
-              <th scope='row'>Heads Up Display (DEPRECATED)</th>
+              <th scope='row'>Heads Up Display (DEPRICIATED)</th>
               <td>libcolumbus,<br /> hud,
                 <br /> libhud-qt
               </td>
@@ -86,7 +92,7 @@
             </tr>
 
             <tr>
-              <th scope='row'>Indicator and D-Bus framework for the panel indicators (DEPRECATED)</th>
+              <th scope='row'>Indicator and D-Bus framework for the panel indicators (DEPRICIATED)</th>
               <td>indicator-applet,<br />libindicate,<br /> libindicator,
                 <br /> dbusmenu,
                 <br /> dbus-test-runner
@@ -125,7 +131,7 @@
             </tr>
 
             <tr>
-              <th scope='row'>Legacy Unity shell(formally Ubuntu Netbook Edition user interface) (DEPRECATED)</th>
+              <th scope='row'>Legacy Unity shell(formally Ubuntu Netbook Edition user interface) (DEPRICIATED)</th>
               <td>netbook-remix-launcher,<br /> maximus,
                 <br /> window-picker-applet,
                 <br /> desktop-switcher,
@@ -139,7 +145,7 @@
             </tr>
 
             <tr>
-              <th scope='row'>Libertine aandbox for running Deb-packaged X11-based application in Snappy (DEPRECATED)</th>
+              <th scope='row'>Libertine aandbox for running Deb-packaged X11-based application in Snappy (DEPRICIATED)</th>
               <td>libertine</td>
               <td>Will Cooke (will.cooke&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
             </tr>
@@ -189,8 +195,7 @@
                 <br /> account-plugins,
                 <br /> signon-keyring-extension,
                 <br /> account-plugin-evernote,
-                <br /> ubuntuone-client-data
-                <br /> ubuntu-system-settings-online-accounts,
+                <br /> ubuntuone-client-data ubuntu-system-settings-online-accounts,
                 <br /> online-accounts-api,
                 <br /> unity-control-center-signon
               </td>
@@ -232,7 +237,7 @@
             </tr>
 
             <tr>
-              <th scope='row'>Scopes and lenses for dash (DEPRECATED)</th>
+              <th scope='row'>Scopes and lenses for dash (DEPRICIATED)</th>
               <td>unity-lens-*,<br /> unity-scopes-*,
                 <br /> unity-scope-snappy,
                 <br /> pay-ui
@@ -274,9 +279,8 @@
             </tr>
 
             <tr>
-              <th scope='row'>Storage framework and backup servce (DEPRECATED)</th>
-              <td>storage-framework,
-                <br /> keeper
+              <th scope='row'>Storage framework and backup servce (DEPRICIATED)</th>
+              <td>storage-framework,<br /> keeper
               </td>
               <td>Will Cooke (will.cooke&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
             </tr>
@@ -288,9 +292,8 @@
             </tr>
 
             <tr>
-              <th scope='row'>System indicators and related plugins (DEPRECATED)</th>
-              <td>indicator-*,
-                <br /> libappindicator,
+              <th scope='row'>System indicators and related plugins (DEPRICIATED)</th>
+              <td>indicator-*,<br /> libappindicator,
                 <br /> qmenumodel,
                 <br /> libusermetrics,
                 <br /> unity-gtk-module,
@@ -308,8 +311,7 @@
 
             <tr>
               <th scope='row'>System Settings</th>
-              <td>gsettings-qt,
-                <br /> ubuntu-system-settings-online-accounts,
+              <td>gsettings-qt,<br /> ubuntu-system-settings-online-accounts,
                 <br /> ubuntu-system-settings,
                 <br /> gsettings-ubuntu-touch-schemas
               </td>
@@ -323,9 +325,8 @@
             </tr>
 
             <tr>
-              <th scope='row'>Ubuntu Software Developer Kit (DEPRECATED)</th>
-              <td>ubuntu-ui-extras,
-                <br /> ubuntu-html5-theme,
+              <th scope='row'>Ubuntu Software Developer Kit (DEPRICIATED)</th>
+              <td>ubuntu-ui-extras,<br /> ubuntu-html5-theme,
                 <br /> u1db-qt,
                 <br /> unity-action-api,
                 <br /> qtcreator-plugin-ubuntu,
@@ -348,9 +349,8 @@
             </tr>
 
             <tr>
-              <th scope='row'>Ubuntu core applications (DEPRECATED)</th>
-              <td>camera-app,
-                <br /> gallery-app,
+              <th scope='row'>Ubuntu core applications (DEPRICIATED)</th>
+              <td>camera-app,<br /> gallery-app,
                 <br /> notes-app,
                 <br /> webbrowser-app,
                 <br /> address-book-app,
@@ -400,9 +400,8 @@
             </tr>
 
             <tr>
-              <th scope='row'>Ubuntu Platform integration framework (DEPRECATED)</th>
-              <td>platform-api,
-                <br /> dee,
+              <th scope='row'>Ubuntu Platform integration framework (DEPRICIATED)</th>
+              <td>platform-api,<br /> dee,
                 <br /> qtubuntu-sensors,
                 <br /> dbus-cpp,
                 <br /> powerd,
@@ -429,9 +428,8 @@
             </tr>
 
             <tr>
-              <th scope='row'>Ubuntu services infrastructure (DEPRECATED)</th>
-              <td>account-polld,
-                <br /> address-book-service,
+              <th scope='row'>Ubuntu services infrastructure (DEPRICIATED)</th>
+              <td>account-polld,<br /> address-book-service,
                 <br /> buteo-sync-plugin-contacts,
                 <br /> buteo-syncfw-qml,
                 <br /> content-hub,
@@ -473,8 +471,7 @@
 
             <tr>
               <th scope='row'>Unity7 Shell</th>
-              <td>unity,
-                <br /> compiz,
+              <td>unity,<br /> compiz,
                 <br /> libunity,
                 <br /> libunity-misc,
                 <br /> nux,
@@ -489,9 +486,8 @@
             </tr>
 
             <tr>
-              <th scope='row'>Unity8 Shell (DEPRECATED)</th>
-              <td>unity8,
-                <br /> unity-mir,
+              <th scope='row'>Unity8 Shell (DEPRICIATED)</th>
+              <td>unity8,<br /> unity-mir,
                 <br /> unity-api,
                 <br /> unity-notifications,
                 <br /> unity-scopes-api,
@@ -502,8 +498,7 @@
 
             <tr>
               <th scope='row'>Upstart tasks and services manager</th>
-              <td>upstart,
-                <br /> ubuntu-app-launch
+              <td>upstart,<br /> ubuntu-app-launch
               </td>
               <td>Steve Langasek (steve.langasek&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
             </tr>
@@ -516,12 +511,11 @@
 
             <tr>
               <th scope='row'>Visual Assets</th>
-              <td>ubuntu-wallpapers,
-                <br />ubuntu-mono,
-                <br />notify-osd-icons,
-                <br />ubuntu-themes
+              <td>ubuntu-wallpapers,<br /> ubuntu-mono,
+                <br /> notify-osd-icons,
+                <br /> ubuntu-themes
               </td>
-              <td>Peter Mahnke (peter.mahnke&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
+              <td>Alejandra Obregon (alejandra.obregon&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
             </tr>
 
             <tr>
@@ -531,13 +525,12 @@
             </tr>
 
             <tr>
-              <th scope='row'>Webapps (DEPRECATED)</th>
-              <td>unity-webapps-*,
-                <br />webapps-core,
-                <br />libunity-webapps,
-                <br />unity-chromium-extension,
-                <br />unity-firefox-extension,
-                <br />webapps-applications
+              <th scope='row'>Webapps (DEPRICIATED)</th>
+              <td>unity-webapps-*,<br /> webapps-core,
+                <br /> libunity-webapps,
+                <br /> unity-chromium-extension,
+                <br /> unity-firefox-extension,
+                <br /> webapps-applications
               </td>
               <td>Will Cooke (will.cooke&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
             </tr>
@@ -549,7 +542,7 @@
             </tr>
 
             <tr>
-              <th scope='row'>Zeitgeist Client Library (DEPRECATED)</th>
+              <th scope='row'>Zeitgeist Client Library (DEPRICIATED)</th>
               <td>libzeitgeist</td>
               <td>Will Cooke (will.cooke&nbsp;{at}&nbsp;canonical&nbsp;{dot}&nbsp;com)</td>
             </tr>


### PR DESCRIPTION
## Done

- Update the projects/directory page
- Some whitespace appears, but only candid changed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/projects/directory
- compare to the [spreadsheet](https://docs.google.com/spreadsheets/d/14Smfpq9ttrPt2jPx70NB3QTixH_6h7Ktnp1CihjT1So/edit#gid=0)

## Issue / Card

Fixes #267

