### PR TITLE
Update Vanilla framework to v1.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postcss": "^6.0.8",
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",
-    "vanilla-framework": "1.6.3"
+    "vanilla-framework": "1.6.7"
   },
   "dependencies": {
     "global-nav": "^0.2.2",

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -101,20 +101,6 @@ time {
   overflow-y: hidden;
 }
 
-// XXX Ant: 04.12.17 This can be removed when this is fixed
-// https://github.com/vanilla-framework/vanilla-framework/issues/1478
-.u-align--center {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  p {
-    max-width: none;
-  }
-}
-
 // Override max-width on `p` tags
 .u-no-max-width {
   max-width: 100%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,9 +2812,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.3.tgz#92271d5dc765d7563659684ed4797e3919160f01"
+vanilla-framework@1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.7.tgz#c4fb65674e709abbf7e75a4f14152aa90c99c30f"
 
 vendors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Done
Update Vanilla framework to v1.6.7

## QA
1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. Check the site looks "better" than the live site

## Issue / Card
Fixes https://github.com/canonical-websites/www.canonical.com/issues/269
