### PR TITLE
Rename insights to blog

### DIFF
--- a/templates/_includes/extended-footer.html
+++ b/templates/_includes/extended-footer.html
@@ -25,7 +25,7 @@
         <li><a href="https://www.ubuntu.com" class="p-link--external">Ubuntu</a></li>
         <li><a href="https://www.ubuntu.com/support" class="p-link--external">Ubuntu Advantage</a></li>
         <li><a href="https://partners.ubuntu.com" class="p-link--external">Partnerships</a></li>
-        <li><a href="https://insights.ubuntu.com/press-centre/" class="p-link--external">Press and resources</a></li>
+        <li><a href="https://blog.ubuntu.com/press-centre/" class="p-link--external">Press and resources</a></li>
       </ul>
     </div>
   </div>

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -333,17 +333,17 @@
     </div>
     <div class="row">
       <div class="col-4">
-        <h3><a href="https://insights.ubuntu.com/press-centre/">News &rsaquo;</a></h3>
+        <h3><a href="https://blog.ubuntu.com/press-centre/">News &rsaquo;</a></h3>
         <ul class="p-list--divided">
-          {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?categories=1189" limit=4 as news_items %}
+          {% get_json_feed "https://admin.blog.ubuntu.com/wp-json/wp/v2/posts?categories=1189" limit=4 as news_items %}
           {% include "_includes/article-items.html" with items=news_items %}
         </ul>
     </div>
       <div class="col-4">
-        <h3><a href="https://insights.ubuntu.com/">Resources &rsaquo;</a></h3>
+        <h3><a href="https://blog.ubuntu.com/">Resources &rsaquo;</a></h3>
         <ul class="p-list--divided">
-          {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?categories=1485" limit=2 as white_paper_items %}
-          {% get_json_feed "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?categories=1172" limit=2 as case_study_items %}
+          {% get_json_feed "https://admin.blog.ubuntu.com/wp-json/wp/v2/posts?categories=1485" limit=2 as white_paper_items %}
+          {% get_json_feed "https://admin.blog.ubuntu.com/wp-json/wp/v2/posts?categories=1172" limit=2 as case_study_items %}
           {% include "_includes/article-items.html" with items=white_paper_items %}
           {% include "_includes/article-items.html" with items=case_study_items %}
         </ul>

--- a/templates/services/index.html
+++ b/templates/services/index.html
@@ -130,7 +130,7 @@
       </div>
     </div>
     <div class="col-4 p-divider__block">
-      <h3><a class="p-link--external" href="https://insights.ubuntu.com/2014/03/25/an-ubuntu-pc-for-everyone-in-penn-manor-school-district-pennsylvania-usa/">View case study&nbsp;</a></h3>
+      <h3><a class="p-link--external" href="https://blog.ubuntu.com/2014/03/25/an-ubuntu-pc-for-everyone-in-penn-manor-school-district-pennsylvania-usa/">View case study&nbsp;</a></h3>
       <p>An Ubuntu PC for everyone in Penn Manor School District, Pennsylvania, USA.</p>
     </div>
     <div class="col-4 p-divider__block">

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -13,4 +13,4 @@ def format_date(date):
 
 @register.filter
 def replace_admin(url):
-    return url.replace("admin.insights.ubuntu.com", "insights.ubuntu.com")
+    return url.replace("admin.blog.ubuntu.com", "blog.ubuntu.com")


### PR DESCRIPTION
## Done

Renamed insights to blog

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. Check that links in footer have been updated from insights to blog


## Issue / Card

Fixes [#514](https://github.com/ubuntudesign/web-squad/issues/514)
