### PR TITLE
Fix alignment of logo in a heading

### DIFF
--- a/static/sass/custom/_inline-ubuntu-logo.scss
+++ b/static/sass/custom/_inline-ubuntu-logo.scss
@@ -9,9 +9,8 @@
   display: inline-block;
   height: 1em;
   margin-left: 0.1em;
-  margin-top: -.25rem;
   text-indent: -99999px;
   width: 150px;
   position: relative;
-  top: -.15rem;
+  top: .2rem;
 }


### PR DESCRIPTION
## Done

- Fix alignment of logo image in 'We deliver Ubuntu' heading

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. Check that the Ubuntu logo in the 'We deliver Ubuntu' heading is baseline aligned


## Issue / Card

Fixes [#278](https://github.com/canonical-websites/www.canonical.com/issues/278)

## Screenshots
![screenshot from 2018-06-05 14-33-43](https://user-images.githubusercontent.com/501889/40979388-91ea36b4-68cd-11e8-9ec2-893f42ca1fbf.png)
![screenshot from 2018-06-05 14-34-08](https://user-images.githubusercontent.com/501889/40979389-92066078-68cd-11e8-99ce-9d467208d5be.png)

