### PR TITLE
Make all footer links the same colour

### DIFF
--- a/templates/_includes/extended-footer.html
+++ b/templates/_includes/extended-footer.html
@@ -3,11 +3,11 @@
     <div class="col-4 p-divider__block">
       <h4 class="p-muted-heading">Canonical</h4>
       <ul class="p-list">
-        <li><a class="p-link--soft" href="/products">Products</a></li>
-        <li><a class="p-link--soft" href="/services">Services</a></li>
-        <li><a class="p-link--soft" href="/partners">Partners</a></li>
-        <li><a class="p-link--soft" href="/about">About</a></li>
-        <li><a class="p-link--soft" href="/careers">Careers</a></li>
+        <li><a class="p-link" href="/products">Products</a></li>
+        <li><a class="p-link" href="/services">Services</a></li>
+        <li><a class="p-link" href="/partners">Partners</a></li>
+        <li><a class="p-link" href="/about">About</a></li>
+        <li><a class="p-link" href="/careers">Careers</a></li>
       </ul>
     </div>
     <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done

Make all the links in the extended footer the same colour

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. See the footer lists links are all the same colour (blue)


## Issue / Card

Fixes #201 

## Screenshots

[if relevant, include a screenshot]
![screenshot from 2018-06-08 15-27-58](https://user-images.githubusercontent.com/501889/41163444-93b36726-6b30-11e8-91be-21e3e6fce091.png)
