### PR TITLE
Replace the developer blog with Ubuntu blog on careers

### DIFF
--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -90,8 +90,8 @@
       <p>On the Ubuntu design blog, Canonical&rsquo;s design team shares their process, thoughts and inspiration.</p>
     </div>
     <div class="col-3 p-divider__block">
-      <h3><a href="http://developer.ubuntu.com/blog/" class="p-link--external">Ubuntu developer blog</a></h3>
-      <p>On this blog, the latest community news is shared by Canonical&rsquo;s technical engineers.</p>
+      <h3><a href="https://blog.ubuntu.com/" class="p-link--external">Ubuntu blog</a></h3>
+      <p>On this blog, the latest community news is shared by various teams within Canonical.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Replaced the links and content from the developer blog block with Ubuntu blog.

## QA
1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/careers](http://0.0.0.0:8002/careers)
4. Scroll down to the "Find roles" section
5. See that the right-hand block matches the [copy doc](https://docs.google.com/document/d/17bKqLEPETybsEDqVtIHyAHImOeise8i-O6Xh1S0bV3o/edit#)

## Issue / Card
Fixes https://github.com/canonical-websites/www.canonical.com/issues/288
