### PR TITLE
Add Boston office

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -222,11 +222,24 @@
         <p>Canonical USA Inc.<br />
           <span itemprop="streetAddress">Link Flex</span><br />
           <span itemprop="streetAddress">2301 W Anderson Ln</span><br />
-          <span itemprop="addressRegion">Austin</span>, <span itemprop="postalCode">TX 78757</span><br />
+          <span itemprop="addressRegion">Austin, TX</span> <span itemprop="postalCode">78757</span><br />
           <span itemprop="addressCountry">United States of America</span><br />
           <a href="https://www.google.co.uk/maps/place/Austin,+TX,+USA/@30.3074624,-98.0335911,10z/data=!3m1!4b1!4m5!3m4!1s0x8644b599a0cc032f:0x5d9b464bd469d57a!8m2!3d30.267153!4d-97.7430608">View map &rsaquo;</a></p>
       </div>
     </div>
+
+    <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content p-card address">
+      <div>
+        <h3 class="title">Boston, United States</h3>
+        <p>Canonical USA Inc.<br />
+          <span itemprop="streetAddress">18 Tremont Street</span><br />
+          <span itemprop="streetAddress">Suite 210</span><br />
+          <span itemprop="addressRegion">Boston, MA </span> <span itemprop="postalCode">02108</span><br />
+          <span itemprop="addressCountry">United States of America</span><br />
+          <a href="https://www.google.co.uk/maps/place/18+Tremont+St+%23210,+Boston,+MA+02108,+USA/@42.3587826,-71.0618133,17z/data=!3m1!4b1!4m5!3m4!1s0x89e37084ec2b3cfd:0x4bf983a8c4e91765!8m2!3d42.3587826!4d-71.0596246">View map &rsaquo;</a></p>
+      </div>
+    </div>
+
 
     <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="tabbed-content p-card address">
       <div>

--- a/templates/about/map.html
+++ b/templates/about/map.html
@@ -46,6 +46,12 @@
         '2301 W Anderson Ln <br />' +
         'Austin, TX 78757<br />USA</p>'
       });
+      var bostonInfo = new google.maps.InfoWindow({
+        content: '<h2>Boston, USA</h2>' +
+        '<p>Canonical USA, Inc. <br />' +
+        '18 Tremont Street, Suite 210 <br />' +
+        'Boston, MA 02108 <br />USA</p>'
+      });
       var shanghaiInfo = new google.maps.InfoWindow({
         content: '<h2>Shanghai, China</h2>' +
         '<p>Room 1246, 12F <br />' +
@@ -98,6 +104,11 @@
               map: map,
               title: "Austin, United States"
             });
+            var boston = new google.maps.Marker({
+              position: new google.maps.LatLng(42.359195, -71.059646),
+              map: map,
+              title: "Boston, United States"
+            });
             var shanghai = new google.maps.Marker({
               position: new google.maps.LatLng(31.1747322, 121.4351965),
               map: map,
@@ -126,6 +137,7 @@
 
             google.maps.event.addListener(london, 'click', function() {
               austinInfo.close();
+              bostonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
               taipeiInfo.close();
@@ -134,6 +146,7 @@
               londonInfo.open(map, london);
             });
             google.maps.event.addListener(austin, 'click', function() {
+              bostonInfo.close();
               londonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
@@ -142,8 +155,19 @@
               japanInfo.close();
               austinInfo.open(map, austin);
             });
+            google.maps.event.addListener(boston, 'click', function() {
+              austinInfo.close();
+              londonInfo.close();
+              shanghaiInfo.close();
+              beijingInfo.close();
+              taipeiInfo.close();
+              iomInfo.close();
+              japanInfo.close();
+              bostonInfo.open(map, boston);
+            });
             google.maps.event.addListener(shanghai, 'click', function() {
               austinInfo.close();
+              bostonInfo.close();
               londonInfo.close();
               beijingInfo.close();
               taipeiInfo.close();
@@ -153,6 +177,7 @@
             });
             google.maps.event.addListener(beijing, 'click', function() {
               austinInfo.close();
+              bostonInfo.close();
               shanghaiInfo.close();
               londonInfo.close();
               taipeiInfo.close();
@@ -162,6 +187,7 @@
             });
             google.maps.event.addListener(taipei, 'click', function() {
               austinInfo.close();
+              bostonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
               londonInfo.close();
@@ -171,6 +197,7 @@
             });
             google.maps.event.addListener(iom, 'click', function() {
               austinInfo.close();
+              bostonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
               taipeiInfo.close();
@@ -180,6 +207,7 @@
             });
             google.maps.event.addListener(japan, 'click', function() {
               austinInfo.close();
+              bostonInfo.close();
               shanghaiInfo.close();
               beijingInfo.close();
               taipeiInfo.close();


### PR DESCRIPTION
## Done

* Added the Boston office to the /about map

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://localhost:8002/about](http://localhost:8002/about)
4. See that the Boston office has a marker and a card when you click on it.
5. See that it hides when you click on another marker

_Note, the map api might not work on the demo_

## Issue / Card

Fixes #295 