### PR TITLE
Fix lint error in views.py

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -7,12 +7,14 @@ from django_template_finder_view import TemplateFinder
 from webapp.templatetags.raw_feeds import get_raw_json_feed
 from django.views.static import serve
 
+
 def cert_view(request):
     return serve(
         request,
         path='files/secure-boot-master-ca.crl',
         document_root=settings.STATIC_ROOT
     )
+
 
 class GreenhouseVacancies(TemplateView):
     template_name = "careers/all-vacancies.html"


### PR DESCRIPTION
Add new lines to views.py to fix:

```
./webapp/views.py:10:1: E302 expected 2 blank lines, found 1
./webapp/views.py:17:1: E302 expected 2 blank lines, found 1
```

The CI tests should pass correctly with this PR.