### PR TITLE
Copyedits “Products” page

### DIFF
--- a/templates/products/index.html
+++ b/templates/products/index.html
@@ -1,7 +1,7 @@
 {% extends "products/base_products.html" %}
 
 {% block title %}Canonical | Products{% endblock %}
-{% block meta_description %}Canonical provides commercial services for Ubuntu’s users, while working with hardware manufacturers, software vendors and cloud partners to certify Ubuntu. {% endblock %}
+{% block meta_description %}Canonical provides commercial services for Ubuntu users, while working with hardware manufacturers, software vendors and cloud partners to certify Ubuntu. {% endblock %}
 
 {% block content %}
 
@@ -105,13 +105,13 @@
   <div class="row">
     <div class="col-6">
       <h2>On the client: devops for IoT</h2>
-      <p>Ubuntu is the preferred development environment for embedded engineers. It is widely used in <a class="p-link--external" href="https://www.ubuntu.com/internet-of-things">IoT devices</a> across verticals: automotive, industrial, robotics, networking and digital signage. Canonical works with semiconductors to make certified Ubuntu images that brings the best performance out of their hardware.</p>
-      <p>With snaps, the universal Linux packaging system, and <a class="p-link--external" href="https://snapcraft.io">snapcraft.io</a> developers can easily build and distribute their software across multiple devices and environments. And Ubuntu Core is the all snap version of Ubuntu, built for security.</p>
+      <p>Ubuntu is the preferred development environment for embedded engineers. It is widely used in <a class="p-link--external" href="https://www.ubuntu.com/internet-of-things">IoT devices</a> across automotive, industrial, robotics, networking and digital signage. Canonical works with semiconductors to make certified Ubuntu images that brings the best performance out of their hardware.</p>
+      <p>With snaps, the universal Linux packaging system, and <a class="p-link--external" href="https://snapcraft.io">snapcraft.io</a> developers can easily build and distribute their software across multiple devices and environments. And Ubuntu Core is the all-snap version of Ubuntu, built for security.</p>
     </div>
     <div class="col-6">
       <h2>On PCs: supported desktop</h2>
-      <p>The Ubuntu desktop is not only the environment of choice for millions of developers but also enterprises, government, educational institutions and anyone looking for a reliable, ease to use, versatile and secure operating system. Canonical offers support for enterprise desktop users with <a href="https://www.ubuntu.com/support" class="p-link--external">Ubuntu Advantage</a>.</p>
-      <p>Canonical works with most of the world&#39;s PC makers, to <a class="p-link--external" href="https://certification.ubuntu.com/">certify</a> Ubuntu for use on a huge range of devices. As a result, Ubuntu is now available on computers for sale in retailers and online across the globe.</p>
+      <p>The Ubuntu desktop is not only the environment of choice for millions of developers but also enterprises, governments, educational institutions and anyone looking for a reliable, easy-to-use, versatile and secure operating system. Canonical offers support for enterprise desktop users with <a href="https://www.ubuntu.com/support" class="p-link--external">Ubuntu Advantage</a>.</p>
+      <p>Canonical works with most of the world&#39;s PC makers to <a class="p-link--external" href="https://certification.ubuntu.com/">certify</a> Ubuntu for use on a huge range of devices. As a result, Ubuntu is now available on computers for sale in retailers and online across the globe.</p>
     </div>
   </div>
 </section>

--- a/templates/products/index.html
+++ b/templates/products/index.html
@@ -105,7 +105,7 @@
   <div class="row">
     <div class="col-6">
       <h2>On the client: devops for IoT</h2>
-      <p>Ubuntu is the preferred development environment for embedded engineers. It is widely used in <a class="p-link--external" href="https://www.ubuntu.com/internet-of-things">IoT devices</a> across automotive, industrial, robotics, networking and digital signage. Canonical works with semiconductors to make certified Ubuntu images that brings the best performance out of their hardware.</p>
+      <p>Ubuntu is the preferred development environment for embedded engineers. It is widely used in <a class="p-link--external" href="https://www.ubuntu.com/internet-of-things">IoT devices</a> across automotive, industrial, robotics, networking and digital signage industries. Canonical works with semiconductors to make certified Ubuntu images that brings the best performance out of their hardware.</p>
       <p>With snaps, the universal Linux packaging system, and <a class="p-link--external" href="https://snapcraft.io">snapcraft.io</a> developers can easily build and distribute their software across multiple devices and environments. And Ubuntu Core is the all-snap version of Ubuntu, built for security.</p>
     </div>
     <div class="col-6">


### PR DESCRIPTION
## Done

- “verticals” > “industries” (more polite)
- “the all snap version of Ubuntu” > “the all-snap version of Ubuntu” (hyphenates pre-noun adjective phrase)
- “enterprises, government, educational institutions” > “enterprises, governments, educational institutions” (uses plurals consistently)
- “Canonical works with most of the world’s PC makers, to” > Canonical works with most of the world’s PC makers to” (drops unmatched clause marker)
- “ease to use” > “easy-to-use” (hyphenates pre-noun adjective phrase)