### PR TITLE
Upgrade to Django 1.11.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachecontrol==0.11.6
 canonicalwebteam.versioned-static==1.0.1
 canonicalwebteam.get-feeds==0.1.7
 lockfile==0.12.2
-Django==1.11.1
+Django==1.11.16
 whitenoise==3.3.0
 django-template-finder-view==0.2
 django-json-redirects==0.3


### PR DESCRIPTION
Fixes GitHub's security alert for https://nvd.nist.gov/vuln/detail/CVE-2018-14574

(Although this vulnerability didn't actually effect us, as we don't use `APPEND_SLASH = True`)

Qa
--

`./run` the site, thoroughly check it still works, especially complex parts like the careers feed.