### PR TITLE
Removed google plus from the footer and about page

### DIFF
--- a/templates/_includes/extended-footer.html
+++ b/templates/_includes/extended-footer.html
@@ -14,7 +14,6 @@
       <h4 class="p-muted-heading">Follow Us</h4>
       <ul class="p-list">
         <li><a href="https://twitter.com/Canonical" class="p-link--external">Twitter</a></li>
-        <li><a href="https://plus.google.com/116469902245452284818/posts" class="p-link--external">Google+</a></li>
         <li><a href="https://www.facebook.com/pages/Canonical/125818784107695?fref=ts" class="p-link--external">Facebook</a></li>
         <li><a href="https://blog.canonical.com/" class="p-link--external">Blog</a></li>
       </ul>

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -122,7 +122,6 @@
           <p>Mark founded security specialist Thawte in 1996, and became the first South African in space when he flew to the ISS in 2002 on Soyuz TM-34. He founded Ubuntu and Canonical in 2004, combining responsibility for strategy and user experience at Canonical with roles on the Ubuntu Technical Board and Community Council.</p>
           <ul class="p-list">
             <li><a class="p-link--external" href="https://markshuttleworth.com/">Read Mark's blog</a></li>
-            <li><a class="p-link--external" href="https://plus.google.com/103552930976410494054/posts">Follow Mark on Google+</a></li>
           </ul>
         </div>
         <div class="col-4">


### PR DESCRIPTION
## Done

* Removed google plus from the footer and about page

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/) and [about](http://0.0.0.0:8002/about)
4. See that there is no google+ link


## Issue / Card

Fixes #311

## Screenshots

footer
![image](https://user-images.githubusercontent.com/441217/46677402-7de0e580-cbda-11e8-90e6-be66170d2e72.png)

about
![image](https://user-images.githubusercontent.com/441217/46677388-73265080-cbda-11e8-845b-8be964b13012.png)
