### PR TITLE
Update django dep to 2.1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachecontrol==0.12.5
 canonicalwebteam.versioned-static==1.0.2
 canonicalwebteam.get-feeds==0.2.4
 lockfile==0.12.2
-Django==1.11.20
+Django==2.1.7
 whitenoise==4.1.2
 django-template-finder-view==0.3
 django-json-redirects==0.3


### PR DESCRIPTION
## Done

* Update Django dep to 2.1.7 to silence Github warnings

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8002/](http://0.0.0.0:8002/)
4. Verify no errors
