### PR TITLE
Update /services/contact-us

### DIFF
--- a/templates/services/contact-us.html
+++ b/templates/services/contact-us.html
@@ -1,6 +1,7 @@
 {% extends "services/base_services.html" %}
 
 {% block title %}Contact Canonical | Services{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1qi9Tj8F6fxr1nGk3vs12qEMEXDSiFcVqKeFPqO9nh9U/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/services/contact-us.html
+++ b/templates/services/contact-us.html
@@ -390,7 +390,7 @@
                 </p>
             </li>
             <li class="mktField">
-              <button type="submit" class="mktoButton">Submit</button>
+              <button type="submit" class="p-button--positive u-no-margin--bottom mktoButton">Submit</button>
             </li>
           </ul>
           <input type="hidden" name="formid" class="mktoField" value="1240" />

--- a/templates/services/contact-us.html
+++ b/templates/services/contact-us.html
@@ -384,7 +384,9 @@
               <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
             </li>
             <li>
-              All information provided will be handled in accordance with the Canonical <a href="https://www.ubuntu.com/legal" target="_blank">privacy policy</a>.
+              <p>
+                In submitting this form, I confirm that I have read and agree to <a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a class="p-link--external" href="https://www.ubuntu.com/legal/data-privacy">Privacy Policy</a>.
+                </p>
             </li>
             <li class="mktField">
               <button type="submit" class="mktoButton">Submit</button>


### PR DESCRIPTION
## Done

* Update /services/contact-us with updated data privacy information

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [/services/contact-us](http://0.0.0.0:8002/services/contact-us)
4. Compare to the [copy doc](https://docs.google.com/document/d/1qi9Tj8F6fxr1nGk3vs12qEMEXDSiFcVqKeFPqO9nh9U/edit)

## Issue / Card

Fixes #349